### PR TITLE
Api improvements

### DIFF
--- a/alyx/actions/serializers.py
+++ b/alyx/actions/serializers.py
@@ -93,7 +93,7 @@ class WaterAdministrationListSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = WaterAdministration
-        fields = ('date_time', 'water_administered', 'url')
+        fields = ('date_time', 'water_administered', 'hydrogel', 'url')
         extra_kwargs = {'url': {'view_name': 'water-administration-detail'}}
 
 
@@ -117,5 +117,5 @@ class WaterAdministrationDetailSerializer(serializers.HyperlinkedModelSerializer
 
     class Meta:
         model = WaterAdministration
-        fields = ('subject', 'date_time', 'water_administered', 'user', 'url')
+        fields = ('subject', 'date_time', 'water_administered', 'hydrogel', 'user', 'url')
         extra_kwargs = {'url': {'view_name': 'water-administration-detail'}}

--- a/alyx/actions/views.py
+++ b/alyx/actions/views.py
@@ -9,6 +9,21 @@ from .serializers import (SessionListSerializer,
                           WeighingDetailSerializer,
                           )
 
+import django_filters
+from django_filters.rest_framework import FilterSet
+
+class SessionFilter(FilterSet):
+    subject = django_filters.CharFilter(name='subject__nickname')
+    start_date = django_filters.DateFilter(name='start_time__date',lookup_expr=('exact'))
+    end_date = django_filters.DateFilter(name='end_time__date',lookup_expr=('exact'))
+    starts_before = django_filters.DateFilter(name='start_time',lookup_expr=('lte'))
+    starts_after = django_filters.DateFilter(name='start_time',lookup_expr=('gte'))
+    ends_before = django_filters.DateFilter(name='start_time',lookup_expr=('lte'))
+    ends_after = django_filters.DateFilter(name='start_time',lookup_expr=('gte'))
+
+    class Meta:
+        model = Session
+        exclude = ['json']
 
 class SessionAPIList(generics.ListCreateAPIView):
     """
@@ -17,6 +32,7 @@ class SessionAPIList(generics.ListCreateAPIView):
     queryset = Session.objects.all()
     serializer_class = SessionListSerializer
     permission_classes = (permissions.IsAuthenticated,)
+    filter_class = SessionFilter
 
 
 class SessionAPIDetail(generics.RetrieveUpdateDestroyAPIView):

--- a/alyx/subjects/serializers.py
+++ b/alyx/subjects/serializers.py
@@ -66,7 +66,7 @@ class SubjectListSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Subject
-        fields = ('nickname', 'url', 'responsible_user', 'birth_date', 'death_date',
+        fields = ('nickname', 'id', 'url', 'responsible_user', 'birth_date', 'death_date',
                   'species', 'sex', 'litter', 'strain', 'line', 'notes', 'genotype', 'alive')
         lookup_field = 'nickname'
         extra_kwargs = {'url': {'view_name': 'subject-detail', 'lookup_field': 'nickname'}}
@@ -90,9 +90,9 @@ class SubjectDetailSerializer(SubjectListSerializer):
 
     class Meta:
         model = Subject
-        fields = ('nickname', 'url', 'responsible_user', 'birth_date', 'age_weeks', 'death_date',
-                  'species', 'sex', 'litter', 'strain', 'source', 'line', 'notes',
-                  'actions_sessions', 'weighings', 'water_administrations', 'genotype',
-                  'water_requirement_total', 'water_requirement_remaining')
+        fields = ('nickname', 'url', 'id', 'responsible_user', 'birth_date', 'age_weeks', 'death_date',
+                  'species', 'sex', 'litter', 'strain', 'source', 'line', 'notes', 'actions_sessions',
+                  'weighings', 'water_administrations', 'genotype', 'water_requirement_total',
+                  'water_requirement_remaining')
         lookup_field = 'nickname'
         extra_kwargs = {'url': {'view_name': 'subject-detail', 'lookup_field': 'nickname'}}

--- a/alyx/subjects/serializers.py
+++ b/alyx/subjects/serializers.py
@@ -64,6 +64,12 @@ class SubjectListSerializer(serializers.HyperlinkedModelSerializer):
         allow_null=True,
         required=False)
 
+    @staticmethod
+    def setup_eager_loading(queryset):
+        """ Perform necessary eager loading of data to avoid horrible performance."""
+        queryset = queryset.select_related('responsible_user', 'species', 'strain', 'line', 'litter')
+        return queryset
+
     class Meta:
         model = Subject
         fields = ('nickname', 'id', 'url', 'responsible_user', 'birth_date', 'death_date',

--- a/alyx/subjects/views.py
+++ b/alyx/subjects/views.py
@@ -24,10 +24,10 @@ class SubjectFilter(FilterSet):
 
 class SubjectList(generics.ListCreateAPIView):
     queryset = Subject.objects.all()
+    queryset = SubjectListSerializer.setup_eager_loading(queryset)
     serializer_class = SubjectListSerializer
     permission_classes = (permissions.IsAuthenticated,)
     filter_class = SubjectFilter
-
 
 class SubjectDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = Subject.objects.all()

--- a/alyx/subjects/views.py
+++ b/alyx/subjects/views.py
@@ -1,14 +1,14 @@
 
-from .models import Subject
-
-from .serializers import SubjectListSerializer, SubjectDetailSerializer
+from .models import *
+from .serializers import *
 from rest_framework import generics, permissions
 import django_filters
 from django_filters.rest_framework import FilterSet
 
 
 class SubjectFilter(FilterSet):
-    alive = django_filters.BooleanFilter(name='alive')
+    alive = django_filters.BooleanFilter(name='death_date', lookup_expr='isnull')
+    responsible_user = django_filters.CharFilter(name='responsible_user__username')
 
     class Meta:
         model = Subject
@@ -20,7 +20,6 @@ class SubjectList(generics.ListCreateAPIView):
     serializer_class = SubjectListSerializer
     permission_classes = (permissions.IsAuthenticated,)
     filter_class = SubjectFilter
-    filter_fields = ['__all__', 'alive']
 
 
 class SubjectDetail(generics.RetrieveUpdateDestroyAPIView):

--- a/alyx/subjects/views.py
+++ b/alyx/subjects/views.py
@@ -9,6 +9,13 @@ from django_filters.rest_framework import FilterSet
 class SubjectFilter(FilterSet):
     alive = django_filters.BooleanFilter(name='death_date', lookup_expr='isnull')
     responsible_user = django_filters.CharFilter(name='responsible_user__username')
+    stock = django_filters.BooleanFilter(name='responsible_user', method='filter_stock')
+
+    def filter_stock(self, queryset, name, value):
+        if value == True:
+            return queryset.filter(responsible_user__id=5)
+        else:
+            return queryset.exclude(responsible_user__id=5)
 
     class Meta:
         model = Subject


### PR DESCRIPTION
Closes #203, #205, #70.

Sessions endpoint can now be filtered using the following:

`/sessions?start_date=2017-03-01`
`/sessions?end_date=2017-03-01`
`/sessions?starts_before=2017-03-01`
`/sessions?ends_before=2017-03-01`
`/sessions?starts_after=2017-03-01`
`/sessions?ends_after=2017-03-01`

You can obviously concatenate filters:

`/sessions?starts_after=2017-03-01&starts_before=2017-03-05`

@nsteinme 