### PR TITLE
Fix user-detail URL

### DIFF
--- a/alyx/alyx/urls.py
+++ b/alyx/alyx/urls.py
@@ -142,7 +142,7 @@ urlpatterns = [
 
 
     url(r'^users$', user_list, name='user-list'),
-    url(r'^users/(?P<username>[-_\w].+) $', user_detail, name='user-detail'),
+    url(r'^users/(?P<username>[-_\w].+)$', user_detail, name='user-detail'),
 
     url(r'^water-restricted-subjects$', subjects_views.WaterRestrictedSubjectList.as_view(),
         name="water-restricted-subject-list"),


### PR DESCRIPTION
I couldn't get the user-detail view URL to work at all, and noticed that it had an extra space after the regexp that none of the other URLs had. After removing the space it appears to work fine.