### PR TITLE
Minor fixes and disable time zone

### DIFF
--- a/alyx/actions/serializers.py
+++ b/alyx/actions/serializers.py
@@ -5,6 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 
 from .models import (ProcedureType, Session, WaterAdministration, Weighing)
 from subjects.models import Subject
+from misc.models import OrderedUser
 from data.serializers import ExpMetadataSummarySerializer
 from equipment.models import LabLocation
 
@@ -33,7 +34,7 @@ class BaseActionSerializer(serializers.HyperlinkedModelSerializer):
         read_only=False,
         many=True,
         slug_field='username',
-        queryset=User.objects.all(),
+        queryset=OrderedUser.objects.all(),
         required=False,
     )
 

--- a/alyx/alyx/settings.py
+++ b/alyx/alyx/settings.py
@@ -199,7 +199,7 @@ TIME_ZONE = 'GB'
 
 USE_I18N = False
 USE_L10N = False
-USE_TZ = True
+USE_TZ = False
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.8/howto/static-files/

--- a/alyx/data/views.py
+++ b/alyx/data/views.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 import django_filters
 from django_filters.rest_framework import FilterSet
 
+from misc.models import OrderedUser
 from alyx.settings import TIME_ZONE
 from subjects.models import Subject, Project
 from electrophysiology.models import ExtracellularRecording
@@ -243,7 +244,11 @@ class RegisterFileViewSet(mixins.CreateModelMixin,
     serializer_class = serializers.Serializer
 
     def create(self, request):
-        user = request.data.get('created_by', None) or request.user
+        user = request.data.get('created_by', None)
+        if user:
+            user = OrderedUser.objects.get(username=user)
+        else:
+            user = request.user
         dns = request.data.get('dns', None)
         if not dns:
             raise ValueError("The dns argument is required.")

--- a/alyx/data/views.py
+++ b/alyx/data/views.py
@@ -278,6 +278,8 @@ class RegisterFileViewSet(mixins.CreateModelMixin,
 
         projects = [Project.objects.get(name=project) for project in projects if project]
         repositories = _get_repositories_for_projects(projects or list(subject.projects.all()))
+        if repo not in repositories:
+            repositories += [repo]
 
         session = _get_or_create_session(
             subject=subject, date=date, number=session_number, user=user)


### PR DESCRIPTION
* /register-file now uses the DNS-specified DataRepository to create a default file record.
* USE_TZ is now False, which means that datetimes are now saved in local time instead of UTC. It should make it simpler to make queries using the local time.