### PR TITLE
Release 2018-12-03

### DIFF
--- a/alyx/actions/__init__.py
+++ b/alyx/actions/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'actions.apps.ActionsConfig'

--- a/alyx/actions/apps.py
+++ b/alyx/actions/apps.py
@@ -3,3 +3,4 @@ from django.apps import AppConfig
 
 class ActionsConfig(AppConfig):
     name = 'actions'
+    verbose_name = 'Action admin'

--- a/alyx/actions/serializers.py
+++ b/alyx/actions/serializers.py
@@ -232,5 +232,5 @@ class WaterAdministrationDetailSerializer(serializers.HyperlinkedModelSerializer
     class Meta:
         model = WaterAdministration
         fields = ('subject', 'date_time', 'water_administered', 'water_type', 'user', 'url',
-                  'session')
+                  'session', 'adlib')
         extra_kwargs = {'url': {'view_name': 'water-administration-detail'}}

--- a/alyx/actions/tests_rest.py
+++ b/alyx/actions/tests_rest.py
@@ -66,7 +66,7 @@ class APIActionsTests(BaseTests):
         self.ar(response)
         d = response.data[0]
         self.assertTrue(set(('date_time', 'url', 'subject', 'user',
-                             'water_administered', 'water_type')) <= set(d))
+                             'water_administered', 'water_type', 'adlib')) <= set(d))
 
     def test_list_weighing_1(self):
         url = reverse('weighing-create')

--- a/alyx/actions/tests_rest.py
+++ b/alyx/actions/tests_rest.py
@@ -1,6 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.utils.timezone import now
+from datetime import timedelta
 
 from alyx.base import BaseTests
 from subjects.models import Subject, Project
@@ -95,7 +96,11 @@ class APIActionsTests(BaseTests):
         url = reverse('water-requirement', kwargs={'nickname': self.subject.nickname})
 
         date = now().date()
-        response = self.client.get(url + '?start_date=%s&end_date=%s' % (date, date))
+        start_date = date - timedelta(days=2)
+        end_date = date + timedelta(days=2)
+        response = self.client.get(
+            url + '?start_date=%s&end_date=%s' % (
+                start_date.strftime('%Y-%m-%d'), end_date.strftime('%Y-%m-%d')))
         self.ar(response)
         d = response.data
         self.assertEqual(d['subject'], self.subject.nickname)
@@ -103,6 +108,11 @@ class APIActionsTests(BaseTests):
         self.assertTrue(
             set(('date', 'weight', 'expected_weight', 'expected_water',
                  'given_water_liquid', 'given_water_hydrogel',)) <= set(d['records'][0]))
+        dates = sorted(_['date'] for _ in d['records'])
+        assert len(dates) == 5
+        assert dates[0] == start_date
+        assert dates[-1] == end_date
+        assert dates[2] == date
 
     def test_sessions(self):
         ses_dict = {'subject': self.subject,

--- a/alyx/actions/views.py
+++ b/alyx/actions/views.py
@@ -216,9 +216,9 @@ class WaterRequirement(APIView):
 
     def get(self, request, format=None, nickname=None):
         assert nickname
-        # start_date = request.query_params.get('start_date', None)
-        # end_date = request.query_params.get('end_date', None)
+        start_date = request.query_params.get('start_date', None)
+        end_date = request.query_params.get('end_date', None)
         subject = Subject.objects.get(nickname=nickname)
-        records = subject.water_control.to_jsonable()
+        records = subject.water_control.to_jsonable(start_date=start_date, end_date=end_date)
         data = {'subject': nickname, 'implant_weight': subject.implant_weight, 'records': records}
         return Response(data)

--- a/alyx/actions/water_control.py
+++ b/alyx/actions/water_control.py
@@ -329,7 +329,7 @@ class WaterControl(object):
         """Amount of water that was given in excess at the specified date."""
         return -self.remaining_water(date=date)
 
-    _columns = ('date', 'weighing_at',
+    _columns = ('date', 'weight', 'weighing_at',
                 'reference_weight',
                 'expected_weight',
                 'min_weight',
@@ -408,7 +408,8 @@ class WaterControl(object):
 
         # Axes and legends.
         ax.set_xlim(start, end)
-        eq = 'weight > %.1f*ref + %.1f*zscore' % (self.reference_weight_pct, self.zscore_weight_pct)
+        eq = 'weight > %.1f*ref + %.1f*zscore' % (
+            self.reference_weight_pct, self.zscore_weight_pct)
         ax.set_title("Weighings for %s (%s)" % (self.nickname, eq))
         ax.set_xlabel('Date')
         ax.set_ylabel('Weight (g)')

--- a/alyx/actions/water_control.py
+++ b/alyx/actions/water_control.py
@@ -235,6 +235,12 @@ class WaterControl(object):
         if weighings_before:
             return weighings_before[-1]
 
+    def weighing_at(self, date=None):
+        """Return the weight of the subject at the specified date."""
+        date = date or today()
+        weighings_at = [(d, w) for (d, w) in self.weighings if d.date() == date]
+        return weighings_at[0][1] if weighings_at else None
+
     def current_weighing(self):
         """Return the last known weight."""
         return self.last_weighing_before(date=today())
@@ -323,7 +329,7 @@ class WaterControl(object):
         """Amount of water that was given in excess at the specified date."""
         return -self.remaining_water(date=date)
 
-    _columns = ('date', 'weight',
+    _columns = ('date', 'weighing_at',
                 'reference_weight',
                 'expected_weight',
                 'min_weight',

--- a/alyx/actions/water_control.py
+++ b/alyx/actions/water_control.py
@@ -29,7 +29,7 @@ def today():
 
 
 def date(s):
-    return datetime.strptime(s, '%Y-%M-%d').date()
+    return datetime.strptime(s, '%Y-%m-%d').date()
 
 
 def date_range(start_date, end_date):
@@ -336,15 +336,17 @@ class WaterControl(object):
                 'is_water_restricted',
                 )
 
-    def to_jsonable(self):
+    def to_jsonable(self, start_date=None, end_date=None):
+        start_date = date(start_date) if start_date else self.first_date()
+        end_date = date(end_date) if end_date else today()
         out = []
-        for date in date_range(self.first_date(), today()):
+        for d in date_range(start_date, end_date):
             obj = {}
             for col in self._columns:
                 if col == 'date':
-                    obj['date'] = date
+                    obj['date'] = d
                 else:
-                    obj[col] = getattr(self, col)(date=date)
+                    obj[col] = getattr(self, col)(date=d)
             out.append(obj)
         # return json.dumps(out, cls=DjangoJSONEncoder)
         return out

--- a/alyx/actions/water_control.py
+++ b/alyx/actions/water_control.py
@@ -408,9 +408,11 @@ class WaterControl(object):
 
         # Axes and legends.
         ax.set_xlim(start, end)
-        ax.set_title("Weighings for %s" % self.nickname)
+        eq = 'weight > %.1f*ref + %.1f*zscore' % (self.reference_weight_pct, self.zscore_weight_pct)
+        ax.set_title("Weighings for %s (%s)" % (self.nickname, eq))
         ax.set_xlabel('Date')
         ax.set_ylabel('Weight (g)')
+        ax.legend(['%d%%' % (100 * t[0]) for t in self.thresholds], loc=2)
         ax.grid(True)
         f.tight_layout()
         return return_figure(f)
@@ -432,8 +434,8 @@ def water_control(subject):
         reference_weight_pct=rw_pct,
         zscore_weight_pct=zw_pct,
     )
-    wc.add_threshold(percentage=.8, bgcolor=PALETTE['orange'], fgcolor='#FFC28E')
-    wc.add_threshold(percentage=.7, bgcolor=PALETTE['red'], fgcolor='#F08699')
+    wc.add_threshold(percentage=rw_pct or zw_pct, bgcolor=PALETTE['orange'], fgcolor='#FFC28E')
+    wc.add_threshold(percentage=.7, bgcolor=PALETTE['red'], fgcolor='#F08699', line_style='--')
 
     # Water restrictions.
     wrs = am.WaterRestriction.objects.filter(subject=subject).order_by('start_time')

--- a/alyx/misc/admin.py
+++ b/alyx/misc/admin.py
@@ -9,7 +9,33 @@ from .models import Note, Lab, LabMembership, LabLocation
 from alyx.base import BaseAdmin
 
 
+class LabForm(forms.ModelForm):
+    def __init__(self, *args, **kwargs):
+        super(LabForm, self).__init__(*args, **kwargs)
+        self.fields['reference_weight_pct'].help_text =\
+            'Threshold ratio triggers a warning using the Reference Weight method (0-1)'
+        self.fields['reference_weight_pct'].label = 'Reference Weight Ratio'
+        self.fields['zscore_weight_pct'].help_text =\
+            'Threshold ratio triggers a warning is raised using the Z-Score method (0-1)'
+        self.fields['zscore_weight_pct'].label = 'Reference Weight Ratio'
+
+    def clean_reference_weight_pct(self):
+        ref = self.cleaned_data['reference_weight_pct']
+        ref = max(ref, 0)
+        if ref > 1:
+            ref = ref / 100
+        return ref
+
+    def clean_zscore_weight_pct(self):
+        ref = self.cleaned_data['zscore_weight_pct']
+        ref = max(ref, 0)
+        if ref > 1:
+            ref = ref / 100
+        return ref
+
+
 class LabAdmin(BaseAdmin):
+    form = LabForm
     fields = ['name', 'institution', 'address', 'timezone',
               'reference_weight_pct', 'zscore_weight_pct']
     list_display = fields

--- a/alyx/subjects/__init__.py
+++ b/alyx/subjects/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'subjects.apps.SubjectsConfig'

--- a/alyx/subjects/apps.py
+++ b/alyx/subjects/apps.py
@@ -3,3 +3,4 @@ from django.apps import AppConfig
 
 class SubjectsConfig(AppConfig):
     name = 'subjects'
+    verbose_name = 'Subject admin'

--- a/alyx/subjects/models.py
+++ b/alyx/subjects/models.py
@@ -529,7 +529,7 @@ class Line(BaseModel):
         ordering = ['name']
 
     def __str__(self):
-        return self.nickname
+        return self.name
 
     def new_breeding_pair_autoname(self):
         self.breeding_pair_autoname_index = self.breeding_pair_autoname_index + 1

--- a/alyx/templates/admin/base.html
+++ b/alyx/templates/admin/base.html
@@ -2,6 +2,11 @@
 {% load i18n admin_urls static admin_list %}
 
 {% block userlinks %}
+    go to
+    <a href="/admin/subjects">subjects</a> /
+    <a href="/admin/actions">actions</a> /
+    <a href="/admin/data">data</a> /
+    <a href="/admin/misc">misc</a> /
     {{ block.super }} /
     <a href="https://github.com/cortex-lab/alyx/issues">{% trans 'Report a problem' %}</a>
 {% endblock %}

--- a/alyx/templates/water_history.html
+++ b/alyx/templates/water_history.html
@@ -7,7 +7,7 @@
 <div>
 <img src="{{ plot_url }}" />
 </div>
-    
+
 <table>
 <thead>
     <tr>
@@ -28,7 +28,7 @@
 {% for obj in object_list %}
     <tr>
         <td>{{ obj.date | date }}</td>
-        <td>{{ obj.weight | floatformat:1 }}</td>
+        <td>{{ obj.weighing_at | floatformat:1 }}</td>
         <td>{{ obj.reference_weight | floatformat:1 }}</td>
         <td>{{ obj.expected_weight | floatformat:1 }}</td>
         <td>{{ obj.percentage_weight | floatformat:1 }}</td>

--- a/utils/export_ibl/export.sh
+++ b/utils/export_ibl/export.sh
@@ -1,7 +1,0 @@
-echo "Recreating the temporary database"
-psql -h localhost -U cyrille -d alyx -c 'DROP DATABASE IF EXISTS alyx_ibl_tmp;'
-psql -h localhost -U cyrille -d alyx -c 'CREATE DATABASE alyx_ibl_tmp WITH TEMPLATE alyx OWNER cyrille;'
-echo "Cascade deleting all non-IBL subjects"
-python alyx/manage.py shell -c "from subjects.models import Subject; Subject.objects.using('ibl_tmp').exclude(projects__name__icontains='ibl').delete()"
-echo "Creating the JSON dump"
-python alyx/manage.py dumpdata -e contenttypes -e auth.permission -e reversion.version -e reversion.revision -e admin.logentry -e authtoken.token -e auth.group --indent 1 --database ibl_tmp -o dump_ibl.json


### PR DESCRIPTION
- add start_date, end_date filters in water requirement endpoint
- in chronological water admin tables, display each date's weighing instead of the last known weighing
- add plot legends
- a few cosmetic improvement in the admin interface