### PR TITLE
Pagination

### DIFF
--- a/alyx/actions/serializers.py
+++ b/alyx/actions/serializers.py
@@ -96,30 +96,15 @@ class SessionWaterAdminSerializer(serializers.ModelSerializer):
 
 class SessionListSerializer(BaseActionSerializer):
 
-    data_dataset_session_related = SessionDatasetsSerializer(read_only=True, many=True)
-    wateradmin_session_related = SessionWaterAdminSerializer(read_only=True, many=True)
-
-    project = serializers.SlugRelatedField(read_only=False, slug_field='name', many=False,
-                                           queryset=Project.objects.all(), required=False)
-
     @staticmethod
     def setup_eager_loading(queryset):
         """ Perform necessary eager loading of data to avoid horrible performance."""
-        queryset = queryset.select_related(
-            'subject', 'location', 'parent_session', 'lab', 'project')
-        queryset = queryset.prefetch_related(
-            'users', 'procedures',
-            'data_dataset_session_related',
-            'data_dataset_session_related__dataset_type',
-            'data_dataset_session_related__file_records',
-            'data_dataset_session_related__file_records__data_repository',
-            'wateradmin_session_related',
-        )
-        return queryset
+        queryset = queryset.select_related('subject')
+        return queryset.order_by('-start_time')
 
     class Meta:
         model = Session
-        fields = SESSION_FIELDS
+        fields = ('subject', 'start_time', 'number', 'url')
 
 
 class SessionDetailSerializer(BaseActionSerializer):
@@ -139,7 +124,7 @@ class SessionDetailSerializer(BaseActionSerializer):
             'data_dataset_session_related__file_records__data_repository',
             'wateradmin_session_related',
         )
-        return queryset
+        return queryset.order_by('-start_time')
 
     class Meta:
         model = Session

--- a/alyx/actions/serializers.py
+++ b/alyx/actions/serializers.py
@@ -70,6 +70,20 @@ class BaseActionSerializer(serializers.HyperlinkedModelSerializer):
         required=False,)
 
 
+class LabLocationSerializer(serializers.ModelSerializer):
+
+    lab = serializers.SlugRelatedField(
+        read_only=False,
+        slug_field='name',
+        queryset=Lab.objects.all(),
+        many=False,
+        required=False,)
+
+    class Meta:
+        model = LabLocation
+        fields = ('name', 'lab', 'json')
+
+
 class SessionDatasetsSerializer(serializers.ModelSerializer):
 
     dataset_type = serializers.SlugRelatedField(

--- a/alyx/actions/tests_rest.py
+++ b/alyx/actions/tests_rest.py
@@ -195,3 +195,19 @@ class APIActionsTests(BaseTests):
         response = self.client.get(url)
         d2 = self.ar(response)[0]
         self.assertEqual(d, d2)
+
+    def test_list_retrieve_lab_locations(self):
+        # test list
+        url = reverse('location-list')
+        l = self.ar(self.client.get(url))
+        self.assertTrue(len(l) > 0)
+        self.assertEqual(set(l[0].keys()), {'name', 'json', 'lab'})
+        # test detail
+        url = reverse('location-detail', args=[l[0]['name']])
+        d = self.ar(self.client.get(url))
+        self.assertEqual(d, l[0])
+        # test patch
+        url = reverse('location-detail', args=[l[0]['name']])
+        json_dict = {'string': "look at me! I'm a new Json field"}
+        p = self.ar(self.client.patch(url, data={'json': json.dumps(json_dict)}))
+        self.assertEqual(p['json'], json_dict)

--- a/alyx/actions/views.py
+++ b/alyx/actions/views.py
@@ -19,8 +19,9 @@ from subjects.models import Subject
 from .water_control import water_control, date as get_date
 from .models import (
     BaseAction, Session, WaterAdministration, WaterRestriction,
-    Weighing, WaterType)
-from .serializers import (SessionListSerializer,
+    Weighing, WaterType, LabLocation)
+from .serializers import (LabLocationSerializer,
+                          SessionListSerializer,
                           SessionDetailSerializer,
                           WaterAdministrationDetailSerializer,
                           WeighingDetailSerializer,
@@ -364,3 +365,22 @@ class WaterRestrictionList(generics.ListAPIView):
     serializer_class = WaterRestrictionListSerializer
     permission_classes = (permissions.IsAuthenticated,)
     filter_class = WaterRestrictionFilter
+
+
+class LabLocationList(generics.ListAPIView):
+    """
+    Lists Lab Location
+    """
+    queryset = LabLocation.objects.all()
+    serializer_class = LabLocationSerializer
+    permission_classes = (permissions.IsAuthenticated,)
+
+
+class LabLocationAPIDetails(generics.RetrieveUpdateAPIView):
+    """
+    Allows viewing of full detail and deleting a water administration.
+    """
+    permission_classes = (permissions.IsAuthenticated,)
+    serializer_class = LabLocationSerializer
+    queryset = LabLocation.objects.all()
+    lookup_field = 'name'

--- a/alyx/alyx/base.py
+++ b/alyx/alyx/base.py
@@ -6,6 +6,7 @@ from polymorphic.models import PolymorphicModel
 import sys
 import pytz
 import uuid
+from collections import OrderedDict
 
 from django import forms
 from django.db import models
@@ -338,7 +339,19 @@ class BaseTests(APITestCase):
         call_command('loaddata', op.join(DATA_DIR, 'all_dumped_anon.json.gz'), verbosity=1)
 
     def ar(self, r, code=200):
+        """
+        Asserts that HTTP status code matches expected value and parse data with or without
+         pagination
+        :param r: response object
+        :param code: expected HTTP response code (default 200)
+        :return: data: the data structure without pagination info if paginate activated
+        """
         self.assertTrue(r.status_code == code, r.data)
+        pkeys = set(['count', 'next', 'previous', 'results'])
+        if isinstance(r.data, OrderedDict) and set(r.data.keys()) == pkeys:
+            return r.data['results']
+        else:
+            return r.data
 
 
 mysite = MyAdminSite()

--- a/alyx/alyx/settings.py
+++ b/alyx/alyx/settings.py
@@ -181,8 +181,8 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',),
     'STRICT_JSON': False,
-    #'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
-    #'PAGE_SIZE': 100
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    'PAGE_SIZE': 100
 }
 
 # Internationalization

--- a/alyx/alyx/settings.py
+++ b/alyx/alyx/settings.py
@@ -181,8 +181,8 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',),
     'STRICT_JSON': False,
-    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
-    'PAGE_SIZE': 100
+    # 'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    # 'PAGE_SIZE': 100
 }
 
 # Internationalization

--- a/alyx/alyx/urls.py
+++ b/alyx/alyx/urls.py
@@ -94,6 +94,12 @@ urlpatterns = [
     path('labs/<str:name>', mv.LabDetail.as_view(),
          name="lab-detail"),
 
+    path('locations', av.LabLocationList.as_view(),
+         name="location-list"),
+
+    path('locations/<str:name>', av.LabLocationAPIDetails.as_view(),
+         name="location-detail"),
+
     path('new-download', new_download, name='new-download'),
 
     path('projects', sv.ProjectList.as_view(),

--- a/alyx/misc/tests_rest.py
+++ b/alyx/misc/tests_rest.py
@@ -16,8 +16,7 @@ class APIActionsTests(BaseTests):
     def test_create_lab_membership(self):
         # first test creation of lab through rest endpoint
         response = self.client.post(reverse('lab-list'), {'name': 'superlab'})
-        self.ar(response, 201)
-        d = response.data
+        d = self.ar(response, 201)
         self.assertTrue(d['name'])
         # create a membership
         lm = LabMembership.objects.create(user=self.superuser, lab=self.lab)
@@ -35,8 +34,7 @@ class APIActionsTests(BaseTests):
         self.assertTrue(set(self.superuser.lab) == set(['superlab', self.lab.name]))
         # now makes sure the REST endpoint returns the same thing
         response = self.client.get(reverse('user-list') + '/test')
-        self.ar(response, 200)
-        d = response.data
+        d = self.ar(response, 200)
         self.assertTrue(set(d['lab']) == set(self.superuser.lab))
 
     def test_user_rest(self):

--- a/alyx/subjects/tests_rest.py
+++ b/alyx/subjects/tests_rest.py
@@ -15,26 +15,20 @@ class APISubjectsTests(BaseTests):
 
     def test_list_subjects(self):
         url = reverse('subject-list')
-        response = self.client.get(url)
-        self.ar(response)
-        d = response.data
+        d = self.ar(self.client.get(url, data={'limit': 300}))
         self.assertTrue(len(d) > 200)
         self.assertTrue(set(('nickname', 'id', 'responsible_user', 'death_date',
                              'line', 'litter', 'sex', 'genotype', 'url')) <= set(d[0]))
 
     def test_list_alive_subjects(self):
-        url = reverse('subject-list') + '?alive=True&stock=True'
-        response = self.client.get(url)
-        self.ar(response)
-        d = response.data
+        url = reverse('subject-list') + '?alive=True&stock=True&limit=300'
+        d = self.ar(self.client.get(url))
         self.assertTrue(len(d) > 200)
         self.assertTrue(set(('nickname', 'id', 'responsible_user', 'death_date')) <= set(d[0]))
 
         # also test that you can get some back when asking for non-stock
         url = reverse('subject-list') + '?alive=True&stock=False'
-        response = self.client.get(url)
-        self.ar(response)
-        d = response.data
+        d = self.ar(self.client.get(url))
         self.assertTrue(len(d) > 0)
         self.assertTrue(set(('nickname', 'id', 'responsible_user', 'death_date')) <= set(d[0]))
 
@@ -42,13 +36,11 @@ class APISubjectsTests(BaseTests):
         # test the individual subject endpoint, i.e. when you ask for a subject by name
         url = reverse('subject-list')
         response = self.client.get(url)
-        self.ar(response)
-        d = response.data
+        d = self.ar(response)
 
         # Ask for the first subject
         response = self.client.get(d[0]['url'])
-        self.ar(response)
-        d = response.data
+        d = self.ar(response)
 
         self.assertTrue(set(('nickname', 'id', 'responsible_user', 'death_date', 'line', 'litter',
                              'sex', 'genotype', 'url', 'expected_water',
@@ -59,16 +51,14 @@ class APISubjectsTests(BaseTests):
         url = reverse('project-list')
         self.client.post(url, {'name': 'test_project'})
         response = self.client.get(url)
-        self.ar(response)
-        d = response.data
+        d = self.ar(response)
         self.assertTrue('test_project' in [p['name'] for p in d])
 
     def test_subject_water_administration(self):
         subject = WaterAdministration.objects.first().subject
         url = reverse('subject-detail', kwargs={'nickname': subject.nickname})
         response = self.client.get(url)
-        self.ar(response)
-        d = response.data
+        d = self.ar(response)
 
         self.assertTrue('water_administrations' in d)
         self.assertTrue(d['water_administrations'])
@@ -79,8 +69,7 @@ class APISubjectsTests(BaseTests):
         subject = Weighing.objects.first().subject
         url = reverse('subject-detail', kwargs={'nickname': subject.nickname})
         response = self.client.get(url)
-        self.ar(response)
-        d = response.data
+        d = self.ar(response)
 
         self.assertTrue('weighings' in d)
         self.assertTrue(d['weighings'])
@@ -93,10 +82,9 @@ class APISubjectsTests(BaseTests):
         sub.lab = self.lab
         sub.save()
         url = reverse('subject-list') + '?lab=' + self.lab.name
-        response = self.client.get(url)
-        self.ar(response)
-        self.assertTrue(len(response.data) == 1)
-        self.assertEqual(response.data[0]['id'], str(sub.pk))
+        d = self.ar(self.client.get(url))
+        self.assertTrue(len(d) == 1)
+        self.assertEqual(d[0]['id'], str(sub.pk))
 
     def test_subject_filters_project(self):
         # test subjects lab filter
@@ -104,27 +92,24 @@ class APISubjectsTests(BaseTests):
         sub.projects.set([self.project])
         sub.save()
         url = reverse('subject-list') + '?project=' + self.project.name
-        response = self.client.get(url)
-        self.ar(response)
-        self.assertTrue(len(response.data) == 1)
-        self.assertEqual(response.data[0]['id'], str(sub.pk))
+        d = self.ar(self.client.get(url))
+        self.assertTrue(len(d) == 1)
+        self.assertEqual(d[0]['id'], str(sub.pk))
 
     def test_subject_filters_water_restriction(self):
         #  makes sure the endpoint only returns alive subjects
         url = reverse('subject-list') + '?water_restricted=True'
-        response = self.client.get(url)
-        self.ar(response)
-        swr = response.data
+        swr = self.ar(self.client.get(url))
         self.assertTrue([d['alive'] for d in swr])
         url = reverse('subject-list') + '?water_restricted=False'
-        non_swr = self.client.get(url).data
+        non_swr = self.ar(self.client.get(url))
         self.assertTrue([d['alive'] for d in non_swr])
         # paranoid: query dead subjects, alive subjects and make sure all wr subjects are
         # within the alive set but excluded from the dead set
-        url = reverse('subject-list') + '?alive=False'
-        dead = self.client.get(url).data
-        url = reverse('subject-list') + '?alive=True'
-        alive = self.client.get(url).data
+        url = reverse('subject-list') + '?alive=False&limit=1000'
+        dead = self.ar(self.client.get(url))
+        url = reverse('subject-list') + '?alive=True&limit=1000'
+        alive = self.ar(self.client.get(url))
         id_alive = set([d['id'] for d in alive])
         id_dead = set([d['id'] for d in dead])
         id_swr = set([d['id'] for d in swr])
@@ -137,7 +122,6 @@ class APISubjectsTests(BaseTests):
     def test_subject_restricted(self):
         url = reverse('water-restricted-subject-list')
         response = self.client.get(url)
-        self.ar(response)
-        d = response.data
+        d = self.ar(response)
         self.assertTrue(set(('nickname', 'expected_water',
                              'remaining_water')) <= set(d[0]))


### PR DESCRIPTION
So this contains pagination settings, and the fixing of the REST tests so they can run with and without pagination (from the `ar` ie. assert response method of base tests parse the data output depending on paginated response or not). You can add the `&limit=500` parameter at the end of the endpoint url (after the filters if any). It defaults to 100.

The second change concerns the sessions-list endpoint, that I've set to return only minimal information: eid, subject, start_date and number. Note that you can still use the REST filters on all the fields even if they're not included in the response (dataset-types for example). I want to be able to return thousand of sessions in a decent time (tens of seconds at most).

Let me know !