### PR TITLE
Added namespace wildcard to dataset types that exist outside of IBL

### DIFF
--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -37,10 +37,10 @@
   "pk": "07aea4a4-189c-46f7-867d-8179561caf94",
   "fields": {
    "json": null,
-   "name": "_ibl_passiveTrials.included",
+   "name": "passiveTrials.included",
    "created_by": null,
    "description": "boolean suggesting which trials to include in analysis, chosen at experimenter discretion, e.g. by excluding the block of incorrect trials at the end of the session when the mouse has stopped",
-   "filename_pattern": "_ibl_passiveTrials.included.*"
+   "filename_pattern": "*passiveTrials.included.*"
   }
  },
  {
@@ -48,10 +48,10 @@
   "pk": "0c635fca-650e-45c9-8e23-b22fe1f6e60e",
   "fields": {
    "json": null,
-   "name": "_ibl_passiveTrials.stimOn_times",
+   "name": "passiveTrials.stimOn_times",
    "created_by": null,
    "description": "Times of stimulus onset in absolute seconds",
-   "filename_pattern": "_ibl_passiveTrials.stimOn_times.*"
+   "filename_pattern": "*passiveTrials.stimOn_times.*"
   }
  },
  {
@@ -114,10 +114,10 @@
   "pk": "2a80ad9c-0d66-47b5-9fe4-2624e3dc439e",
   "fields": {
    "json": null,
-   "name": "_ibl_sparseNoise.xyPos",
+   "name": "sparseNoise.xyPos",
    "created_by": null,
    "description": "2 column array giving x and y coordiates on screen of sparse noise stimulus squares (WHAT UNIT?)",
-   "filename_pattern": "_ibl_sparseNoise.xyPos.*"
+   "filename_pattern": "*sparseNoise.xyPos.*"
   }
  },
  {
@@ -125,10 +125,10 @@
   "pk": "2a9092b0-c9fc-4740-bb43-28b254e3386e",
   "fields": {
    "json": null,
-   "name": "_ibl_trials.feedbackType",
+   "name": "trials.feedbackType",
    "created_by": null,
    "description": "Whether feedback is positive or negative in choiceworld (-1 for negative, +1 for positive)",
-   "filename_pattern": "_ibl_trials.feedbackType.*"
+   "filename_pattern": "*trials.feedbackType.*"
   }
  },
  {
@@ -136,10 +136,10 @@
   "pk": "30717938-d036-40de-942f-b3dfe0c39c3b",
   "fields": {
    "json": null,
-   "name": "_ibl_trials.rewardVolume",
+   "name": "trials.rewardVolume",
    "created_by": null,
    "description": "volume of reward given each trial in \u00b5l",
-   "filename_pattern": "_ibl_trials.rewardVolume.*"
+   "filename_pattern": "*trials.rewardVolume.*"
   }
  },
  {
@@ -158,10 +158,10 @@
   "pk": "361ca040-16e5-45d8-8486-ba8d19538452",
   "fields": {
    "json": null,
-   "name": "_ibl_passiveBeeps.times",
+   "name": "passiveBeeps.times",
    "created_by": null,
    "description": "Times of the beep, equivilent to the go cue during the choice world task",
-   "filename_pattern": "_ibl_passiveBeeps.times.*"
+   "filename_pattern": "*passiveBeeps.times.*"
   }
  },
  {
@@ -169,10 +169,10 @@
   "pk": "378aa050-4924-4a9b-9fe7-b7cf86dff93f",
   "fields": {
    "json": null,
-   "name": "_ibl_trials.choice",
+   "name": "trials.choice",
    "created_by": null,
    "description": "which choice was made in choiceworld: -1 (turn CCW), +1 (turn CW), or 0 (nogo)",
-   "filename_pattern": "_ibl_trials.choice.*"
+   "filename_pattern": "*trials.choice.*"
   }
  },
  {
@@ -191,10 +191,10 @@
   "pk": "4cd7dcc9-62c1-4471-afa7-60544fc7e1ff",
   "fields": {
    "json": null,
-   "name": "_ibl_trials.repNum",
+   "name": "trials.repNum",
    "created_by": null,
    "description": "the repetition number of the trial, i.e. how many trials have been repeated on this side (counting from 1)",
-   "filename_pattern": "_ibl_trials.repNum.*"
+   "filename_pattern": "*trials.repNum.*"
   }
  },
  {
@@ -202,10 +202,10 @@
   "pk": "54c9a39c-665c-4cf6-b06c-d7f18dae1e78",
   "fields": {
    "json": null,
-   "name": "_ibl_wheel.position",
+   "name": "wheel.position",
    "created_by": null,
    "description": "Absolute position of wheel (cm)",
-   "filename_pattern": "_ibl_wheel.position.*"
+   "filename_pattern": "*wheel.position.*"
   }
  },
  {
@@ -224,10 +224,10 @@
   "pk": "5df90bef-df4f-4850-92b4-f0e43d619a0a",
   "fields": {
    "json": null,
-   "name": "_ibl_trials.response_times",
+   "name": "trials.response_times",
    "created_by": null,
    "description": "Time of \"response\" in choiceworld- in absolute seconds, rather than relative to trial onset. This is when one of the three possible choices is registered in software, will not be the same as when the mouse's movement to generate that response begins.",
-   "filename_pattern": "_ibl_trials.response_times.*"
+   "filename_pattern": "*trials.response_times.*"
   }
  },
  {
@@ -257,10 +257,10 @@
   "pk": "678a7e65-1dd1-4bff-b8c9-508e1f3a1cdc",
   "fields": {
    "json": null,
-   "name": "_ibl_trials.intervals",
+   "name": "trials.intervals",
    "created_by": null,
    "description": "2 column array giving each trials start (i.e. beginning of quiescent period) and stop (i.e. end of iti) times of trials in universal seconds",
-   "filename_pattern": "_ibl_trials.intervals.*"
+   "filename_pattern": "*trials.intervals.*"
   }
  },
  {
@@ -268,10 +268,10 @@
   "pk": "6e2913bc-6591-457c-a4e1-df86d96298b4",
   "fields": {
    "json": null,
-   "name": "_ibl_sparseNoise.times",
+   "name": "sparseNoise.times",
    "created_by": null,
    "description": "times of those stimulus squares appeared in universal seconds",
-   "filename_pattern": "_ibl_sparseNoise.times.*"
+   "filename_pattern": "*sparseNoise.times.*"
   }
  },
  {
@@ -290,10 +290,10 @@
   "pk": "72344745-c248-45e5-bf73-a9329c1720d2",
   "fields": {
    "json": null,
-   "name": "_ibl_trials.stimOn_times",
+   "name": "trials.stimOn_times",
    "created_by": null,
    "description": "Times of stimuli in choiceworld - in absolute seconds, rather than relative to trial onset",
-   "filename_pattern": "_ibl_trials.stimOn_times.*"
+   "filename_pattern": "*trials.stimOn_times.*"
   }
  },
  {
@@ -301,10 +301,10 @@
   "pk": "72d9e4b1-295a-4698-bca7-650e7a62a330",
   "fields": {
    "json": null,
-   "name": "_ibl_passiveValveClicks.times",
+   "name": "passiveValveClicks.times",
    "created_by": null,
    "description": "Times of valve opening during passive trial presentation",
-   "filename_pattern": "_ibl_passiveValveClicks.times.*"
+   "filename_pattern": "*passiveValveClicks.times.*"
   }
  },
  {
@@ -312,10 +312,10 @@
   "pk": "74c0120c-7515-478f-9725-53d587d86c49",
   "fields": {
    "json": null,
-   "name": "_ibl_wheel.timestamps",
+   "name": "wheel.timestamps",
    "created_by": null,
    "description": "Timestamps for wheel timeseries",
-   "filename_pattern": "_ibl_wheel.timestamps.*"
+   "filename_pattern": "*wheel.timestamps.*"
   }
  },
  {
@@ -334,10 +334,10 @@
   "pk": "81ea14a9-1512-4c1c-94e3-ccb7b42f6755",
   "fields": {
    "json": null,
-   "name": "_ibl_wheelMoves.type",
+   "name": "wheelMoves.type",
    "created_by": null,
    "description": "string array containing classified type of movement ('CW', 'CCW', 'Flinch', 'Other')",
-   "filename_pattern": "_ibl_wheelMoves.type.*"
+   "filename_pattern": "*wheelMoves.type.*"
   }
  },
  {
@@ -345,10 +345,10 @@
   "pk": "83c45a9b-3e78-460f-a035-cb00cf4f9709",
   "fields": {
    "json": null,
-   "name": "_ibl_passiveNoise.intervals",
+   "name": "passiveNoise.intervals",
    "created_by": null,
    "description": "2 column array giving each passive noise trial's start (i.e. beginning of quiescent period) and stop (i.e. end of iti) times of trials in universal seconds",
-   "filename_pattern": "_ibl_passiveNoise.intervals.*"
+   "filename_pattern": "*passiveNoise.intervals.*"
   }
  },
  {
@@ -444,10 +444,10 @@
   "pk": "979f9f7c-7d67-48d5-9042-a9000a8e66a2",
   "fields": {
    "json": null,
-   "name": "_ibl_trials.contrastLeft",
+   "name": "trials.contrastLeft",
    "created_by": null,
    "description": "contrast of left-side stimulus (0...1) nan if trial is on other side",
-   "filename_pattern": "_ibl_trials.contrastLeft.*"
+   "filename_pattern": "*trials.contrastLeft.*"
   }
  },
  {
@@ -455,10 +455,10 @@
   "pk": "9b929d17-bd42-459d-a604-b4251d847da8",
   "fields": {
    "json": null,
-   "name": "_ibl_passiveTrials.contrastLeft",
+   "name": "passiveTrials.contrastLeft",
    "created_by": null,
    "description": "contrast of left-side stimulus (0...1)",
-   "filename_pattern": "_ibl_passiveTrials.contrastLeft.*"
+   "filename_pattern": "*passiveTrials.contrastLeft.*"
   }
  },
  {
@@ -466,10 +466,10 @@
   "pk": "9d44dc73-67cd-4de7-b115-7d25723bc0da",
   "fields": {
    "json": null,
-   "name": "_ibl_trials.contrastRight",
+   "name": "trials.contrastRight",
    "created_by": null,
    "description": "contrast of right-side stimulus (0...1) nan if trial is on other side",
-   "filename_pattern": "_ibl_trials.contrastRight.*"
+   "filename_pattern": "*trials.contrastRight.*"
   }
  },
  {
@@ -477,10 +477,10 @@
   "pk": "9d9f66f2-a783-46a7-ad03-1cad8aa7b4ab",
   "fields": {
    "json": null,
-   "name": "_ibl_extraRewards.times",
+   "name": "extraRewards.times",
    "created_by": null,
    "description": "Times of extra rewards",
-   "filename_pattern": "_ibl_extraRewards.times.*"
+   "filename_pattern": "*extraRewards.times.*"
   }
  },
  {
@@ -499,10 +499,10 @@
   "pk": "a60425e9-c5ab-4827-88a3-79b4eb68f989",
   "fields": {
    "json": null,
-   "name": "_ibl_trials.feedback_times",
+   "name": "trials.feedback_times",
    "created_by": null,
    "description": "Time of feedback delivery (reward or not) in choiceworld - in absolute seconds, rather than relative to trial onset",
-   "filename_pattern": "_ibl_trials.feedback_times.*"
+   "filename_pattern": "*trials.feedback_times.*"
   }
  },
  {
@@ -510,10 +510,10 @@
   "pk": "b396747f-0c67-4de4-9610-c7e210a5b86a",
   "fields": {
    "json": null,
-   "name": "_ibl_wheel.times",
+   "name": "wheel.times",
    "created_by": null,
    "description": "times of position in absolute seconds from session start",
-   "filename_pattern": "_ibl_wheel.times.*"
+   "filename_pattern": "*wheel.times.*"
   }
  },
  {
@@ -543,10 +543,10 @@
   "pk": "b73caa77-3e26-44a4-9809-b0885b47e77e",
   "fields": {
    "json": null,
-   "name": "_ibl_passiveTrials.contrastRight",
+   "name": "passiveTrials.contrastRight",
    "created_by": null,
    "description": "contrast of right-side stimulus (0...1)",
-   "filename_pattern": "_ibl_passiveTrials.contrastRight.*"
+   "filename_pattern": "*passiveTrials.contrastRight.*"
   }
  },
  {
@@ -576,10 +576,10 @@
   "pk": "cbf4b6b1-9202-4468-bd65-22df1713ae60",
   "fields": {
    "json": null,
-   "name": "_ibl_passiveWhiteNoise.times",
+   "name": "passiveWhiteNoise.times",
    "created_by": null,
    "description": "Times of white noise bursts, equivilent to the negative feedback sound during the choice world task",
-   "filename_pattern": "_ibl_passiveWhiteNoise.times.*"
+   "filename_pattern": "*passiveWhiteNoise.times.*"
   }
  },
  {
@@ -609,10 +609,10 @@
   "pk": "d6584a34-f9dd-4870-ac02-0feb50fdf5f6",
   "fields": {
    "json": null,
-   "name": "_ibl_trials.included",
+   "name": "trials.included",
    "created_by": null,
    "description": "boolean suggesting which trials to include in analysis, chosen at experimenter discretion, e.g. by excluding the block of incorrect trials at the end of the session when the mouse has stopped",
-   "filename_pattern": "_ibl_trials.included.*"
+   "filename_pattern": "*trials.included.*"
   }
  },
  {
@@ -620,10 +620,10 @@
   "pk": "dea53510-d3e0-4b94-9739-2fe548a6f898",
   "fields": {
    "json": null,
-   "name": "_ibl_wheelMoves.intervals",
+   "name": "wheelMoves.intervals",
    "created_by": null,
    "description": "2 column array with onset and offset times of detected wheel movements in seconds",
-   "filename_pattern": "_ibl_wheelMoves.intervals.*"
+   "filename_pattern": "*wheelMoves.intervals.*"
   }
  },
  {
@@ -653,10 +653,10 @@
   "pk": "e1542d34-9618-4369-aab7-0489484f6a12",
   "fields": {
    "json": null,
-   "name": "_ibl_wheel.velocity",
+   "name": "wheel.velocity",
    "created_by": null,
    "description": "Signed velocity of wheel (cm/s) positive = CW",
-   "filename_pattern": "_ibl_wheel.velocity.*"
+   "filename_pattern": "*wheel.velocity.*"
   }
  },
  {
@@ -697,10 +697,10 @@
   "pk": "f010bc2d-0211-41e7-930f-08c927a78d82",
   "fields": {
    "json": null,
-   "name": "_ibl_trials.itiDuration",
+   "name": "trials.itiDuration",
    "created_by": null,
    "description": "Intertrial interval duration for each trial",
-   "filename_pattern": "_ibl_trials.itiDuration.npy"
+   "filename_pattern": "*trials.itiDuration.*"
   }
  },
  {
@@ -708,10 +708,10 @@
   "pk": "f7dbfad8-1cfc-459e-874f-4065cf9def86",
   "fields": {
    "json": null,
-   "name": "_ibl_trials.goCue_times",
+   "name": "trials.goCue_times",
    "created_by": null,
    "description": "Time of go cues in choiceworld - in absolute seconds, rather than relative to trial onset",
-   "filename_pattern": "_ibl_trials.goCue_times.*"
+   "filename_pattern": "*trials.goCue_times.*"
   }
  },
  {


### PR DESCRIPTION
Changes to filename patterns of those dataset types that are (or will be) generated by non-IBL experiments.  Specifically, cortexlab experiments that are run in Rigbox generate `trials` ALF objects that by default have the `_misc_` namespace.  These are currently not registered as they don't match the filename patterns.