### PR TITLE
fix '/docs/' endpoint, broken for recent Django REST framework

### DIFF
--- a/alyx/alyx/settings.py
+++ b/alyx/alyx/settings.py
@@ -192,6 +192,7 @@ REST_FRAMEWORK = {
     # 'DEFAULT_RENDERER_CLASSES': (
     #     'rest_framework.renderers.JSONRenderer',
     # ),
+    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
     'PAGE_SIZE': 250,
 }
 


### PR DESCRIPTION
Hi, I have install Alyx and realised that `/docs` wasn't properly working.

According to https://www.django-rest-framework.org/community/3.10-announcement/#continuing-to-use-coreapi, this additional setting is needed to continue using CoreAPI.

In addition, here is the output of `pip freeze` on my alyx virtual environment, if you need to check the precise version of the dependencies: [pip_freeze_alyx.txt](https://github.com/cortex-lab/alyx/files/3680307/pip_freeze_alyx.txt).