### PR TITLE
Dtypes

### DIFF
--- a/alyx/actions/views.py
+++ b/alyx/actions/views.py
@@ -211,7 +211,7 @@ class SessionFilter(FilterSet):
         dtypes = value.split(',')
         queryset = queryset.filter(data_dataset_session_related__dataset_type__name__in=dtypes)
         queryset = queryset.annotate(
-            dtypes_count=Count('data_dataset_session_related__dataset_type'))
+            dtypes_count=Count('data_dataset_session_related__dataset_type', distinct=True))
         queryset = queryset.filter(dtypes_count__gte=len(dtypes))
         return queryset
 

--- a/alyx/data/fixtures/data.dataformat.json
+++ b/alyx/data/fixtures/data.dataformat.json
@@ -143,6 +143,18 @@
    "python_loader_function": ""
   }
  },
+  {
+  "model": "data.dataformat",
+  "pk": "7f024894-0cf6-4d38-a2a9-54d920627eee",
+  "fields": {
+   "json": null,
+   "name": "meta",
+   "description": "Text file containing electrophysiology acquisition metadata",
+   "file_extension": ".meta",
+   "matlab_loader_function": "",
+   "python_loader_function": ""
+  }
+ },
  {
   "model": "data.dataformat",
   "pk": "f4ef3f1d-a334-4141-a35f-376f6d14eb2f",

--- a/alyx/data/fixtures/data.dataformat.json
+++ b/alyx/data/fixtures/data.dataformat.json
@@ -145,14 +145,14 @@
  },
   {
   "model": "data.dataformat",
-  "pk": "7f024894-0cf6-4d38-a2a9-54d920627eee",
+  "pk": "a8dace55-5134-426c-a615-6591241e7ba0",
   "fields": {
    "json": null,
    "name": "meta",
    "description": "Text file containing electrophysiology acquisition metadata",
    "file_extension": ".meta",
-   "matlab_loader_function": "",
-   "python_loader_function": ""
+   "matlab_loader_function": "ibllib.io.spikeglx.read_meta_data",
+   "python_loader_function": "ibllib.io.spikeglx.read_meta_data"
   }
  },
  {

--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -271,7 +271,7 @@
    "name": "_spikeglx_sync.channels",
    "created_by": null,
    "description": "[nsync]. Sync channel number (0-15)",
-   "filename_pattern": "_spikeglx_sync.channel*.npy"
+   "filename_pattern": "_spikeglx_sync.channels*.npy"
   }
  },
  {
@@ -315,7 +315,7 @@
    "name": "_spikeglx_sync.times",
    "created_by": null,
    "description": "[nsync]Times of sync pulses, seconds relative to ephys start",
-   "filename_pattern": "_spikeglx_sync.time*.npy"
+   "filename_pattern": "_spikeglx_sync.times*.npy"
   }
  },
  {
@@ -557,7 +557,7 @@
    "name": "_spikeglx_sync.polarities",
    "created_by": null,
    "description": "[nsync]. Polarity of front: 1: rising, -1 falling",
-   "filename_pattern": "_spikeglx_sync.polaritie*.npy"
+   "filename_pattern": "_spikeglx_sync.polarities*.npy"
   }
  },
  {

--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -224,7 +224,7 @@
   "pk": "63ea5aaa-1b51-4378-b515-2b6ec0502e05",
   "fields": {
    "json": null,
-   "name": "_ibl_trials.goCueTrigger_times",
+   "name": "trials.goCueTrigger_times",
    "created_by": null,
    "description": "Time of go cues in choiceworld - in absolute seconds, rather than relative to trial onset NOTE: this is the time the trigger command is sent by Bpod",
    "filename_pattern": "_ibl_trials.goCueTrigger_times.*"
@@ -389,7 +389,7 @@
   "pk": "9295f7a4-dd1b-440e-8ad0-53223aebab81",
   "fields": {
    "json": null,
-   "name": "_ibl_trials.probabilityLeft",
+   "name": "trials.probabilityLeft",
    "created_by": null,
    "description": "Probability that the stimulus will be on the left hand side for the current block. The probability of right is 1 minus this",
    "filename_pattern": "_ibl_trials.probabilityLeft.*"

--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -106,7 +106,7 @@
    "name": "clusters.amps",
    "created_by": null,
    "description": "Mean amplitude of each cluster (\u00b5V)",
-   "filename_pattern": "clusters.amps.npy"
+   "filename_pattern": "clusters.amps*.npy"
   }
  },
  {
@@ -832,7 +832,7 @@
    "name": "channels.localCoordinates",
    "created_by": null,
    "description": "relative to probe coordinate system (µm): x (first) dimension is on the width of the shank while (y) is the depth where 0 is the deepest site, and positive above this.",
-   "filename_pattern": "channels.localCoordinates.npy"
+   "filename_pattern": "channels.localCoordinates*.npy"
   }
  },
   {

--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -835,6 +835,17 @@
    "filename_pattern": "channels.localCoordinates.npy"
   }
  },
+  {
+  "model": "data.datasettype",
+  "pk": "94cb84f9-afb9-4285-bf71-333757380261",
+  "fields": {
+   "json": null,
+   "name": "channels._phy_ids",
+   "created_by": null,
+   "description": "Array of integers saying which index in Phy the channel corresponds to (counting from zero).",
+   "filename_pattern": "channels._phy_ids.npy"
+  }
+ },
  {
  "model": "data.datasettype",
  "pk": "8f36fa46-3fbc-4921-be8d-89f838c4ec42",

--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -356,10 +356,10 @@
   "pk": "856ad907-da77-4182-9a34-5eb02b217f2c",
   "fields": {
    "json": null,
-   "name": "clusters.waveformsDuration",
+   "name": "clusters.peakToThrough",
    "created_by": null,
    "description": "Waveforms length in ms",
-   "filename_pattern": "clusters.waveformsDuration*.npy"
+   "filename_pattern": "clusters.peakToThrough*.npy"
   }
  },
  {

--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -356,10 +356,10 @@
   "pk": "856ad907-da77-4182-9a34-5eb02b217f2c",
   "fields": {
    "json": null,
-   "name": "clusters.waveformDuration",
+   "name": "clusters.waveformsDuration",
    "created_by": null,
    "description": "Waveforms length in ms",
-   "filename_pattern": "clusters.waveformDuration.npy"
+   "filename_pattern": "clusters.waveformsDuration.npy"
   }
  },
  {

--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -485,17 +485,6 @@
  },
  {
   "model": "data.datasettype",
-  "pk": "b3e9dded-027e-4cf0-8392-2baeb3bfcabd",
-  "fields": {
-   "json": null,
-   "name": "_iblrig_rightCamera.raw",
-   "created_by": null,
-   "description": "",
-   "filename_pattern": "_iblrig_rightCamera.raw.*"
-  }
- },
- {
-  "model": "data.datasettype",
   "pk": "b5ec79de-9c9e-4009-8892-10aa2ddb9638",
   "fields": {
    "json": null,
@@ -595,17 +584,6 @@
  },
  {
   "model": "data.datasettype",
-  "pk": "df68dbb7-8d0e-4a5b-b829-e2a832a89b62",
-  "fields": {
-   "json": null,
-   "name": "_iblrig_bodyCamera.raw",
-   "created_by": null,
-   "description": "",
-   "filename_pattern": "_iblrig_bodyCamera.raw.*"
-  }
- },
- {
-  "model": "data.datasettype",
   "pk": "e0c77fba-1e8d-435a-b57e-b33c867ede83",
   "fields": {
    "json": null,
@@ -642,10 +620,10 @@
   "pk": "e40899d0-a883-40ac-8214-344bcf249d09",
   "fields": {
    "json": null,
-   "name": "_iblrig_leftCamera.raw",
+   "name": "_iblrig_Camera.raw",
    "created_by": null,
    "description": "",
-   "filename_pattern": "_iblrig_leftCamera.raw.*"
+   "filename_pattern": "_iblrig_*Camera.raw.*"
   }
  },
  {

--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -804,7 +804,7 @@
  },
  {
   "model": "data.datasettype",
-  "pk": "f91db8df-ebdc-448a-9ba2-7b2d003f0c3d",
+  "pk": "56403479-6530-436f-87d5-a1b8b5e1435e",
   "fields": {
    "json": null,
    "name": "clusters.probes",

--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -18,7 +18,7 @@
    "name": "spikes.clusters",
    "created_by": null,
    "description": "[nspi]. Cluster assignments for each spike (integers counting from 0).",
-   "filename_pattern": "spikes.clusters.npy"
+   "filename_pattern": "spikes.clusters*.npy"
   }
  },
  {
@@ -62,7 +62,7 @@
    "name": "spikes.times",
    "created_by": null,
    "description": "[nspi]. Times of spikes (seconds, relative to experiment onset). Note this includes spikes from all probes, merged together",
-   "filename_pattern": "spikes.times.npy"
+   "filename_pattern": "spikes.times*.npy"
   }
  },
  {
@@ -73,7 +73,7 @@
    "name": "spikes.samples",
    "created_by": null,
    "description": "[nspi]. Sample index of spikes in their own electrophysiology binary file.",
-   "filename_pattern": "spikes.samples.npy"
+   "filename_pattern": "spikes.samples*.npy"
   }
  },
  {
@@ -348,7 +348,7 @@
    "name": "spikes.amps",
    "created_by": null,
    "description": "[nspi]. Amplitude of each spike (\u00b5V)",
-   "filename_pattern": "spikes.amps.npy"
+   "filename_pattern": "spikes.amps*.npy"
   }
  },
  {
@@ -359,7 +359,7 @@
    "name": "clusters.waveformsDuration",
    "created_by": null,
    "description": "Waveforms length in ms",
-   "filename_pattern": "clusters.waveformsDuration.npy"
+   "filename_pattern": "clusters.waveformsDuration*.npy"
   }
  },
  {
@@ -414,7 +414,7 @@
    "name": "channels.rawInd",
    "created_by": null,
    "description": "[nch] Each channel's row in its home file (look up via probes.rawFileName), counting from zero. Note some rows don't have a channel, for example if they were sync pulses",
-   "filename_pattern": "channels.rawInd.npy"
+   "filename_pattern": "channels.rawInd*.npy"
   }
  },
  {
@@ -623,7 +623,7 @@
    "name": "clusters.depths",
    "created_by": null,
    "description": "[nc] Depth of mean cluster waveform on probe (\u00b5m). 0 means deepest site, positive means above this.",
-   "filename_pattern": "clusters.depths.npy"
+   "filename_pattern": "clusters.depths*.npy"
   }
  },
  {
@@ -645,7 +645,7 @@
    "name": "spikes.depths",
    "created_by": null,
    "description": "[nspi]. Depth along probe of each spike (\u00b5m; computed from waveform center of mass). 0 means deepest site, positive means above this",
-   "filename_pattern": "spikes.depths.npy"
+   "filename_pattern": "spikes.depths*.npy"
   }
  },
  {
@@ -689,7 +689,7 @@
    "name": "clusters.channels",
    "created_by": null,
    "description": "Channel which has the largest amplitude for this cluster. Note this counts all channels in the whole recording (starting from zero), rather than just the channels on this cluster's home probe - so if you want to find this cluster's brain location, it would be channels.brainLocation[clusters.peakChannel[i],:]",
-   "filename_pattern": "clusters.channels.npy"
+   "filename_pattern": "clusters.channels*.npy"
   }
  },
   {
@@ -799,7 +799,7 @@
    "name": "channels.probes",
    "created_by": null,
    "description": "Probe assignments for each channel (integers counting from 0). Can be used as direct indexing for the probes.* attributes.",
-   "filename_pattern": "channels.probes.npy"
+   "filename_pattern": "channels.probes*.npy"
   }
  },
  {
@@ -810,7 +810,7 @@
    "name": "clusters.probes",
    "created_by": null,
    "description": "Probe assignments for each cluster (integers counting from 0). Can be used as direct indexing for the probes.* attributes.",
-   "filename_pattern": "clusters.probes.npy"
+   "filename_pattern": "clusters.probes*.npy"
   }
  },
  {
@@ -821,7 +821,7 @@
    "name": "spikes.templates",
    "created_by": null,
    "description": "Detection template assignment for each spike (integers counting from 0). Can be used as direct indexing of the templates.* attributes.",
-   "filename_pattern": "spikes.templates.npy"
+   "filename_pattern": "spikes.templates*.npy"
   }
  },
  {
@@ -843,7 +843,7 @@
    "name": "channels._phy_ids",
    "created_by": null,
    "description": "Array of integers saying which index in Phy the channel corresponds to (counting from zero).",
-   "filename_pattern": "channels._phy_ids.npy"
+   "filename_pattern": "channels._phy_ids*.npy"
   }
  },
  {

--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -711,7 +711,7 @@
    "name": "ephysData.raw.ap",
    "created_by": null,
    "description": "Action Potentials band of raw neurophysiology data",
-   "filename_pattern": "*ephysData.raw*.ap.bin"
+   "filename_pattern": "*ephysData*.ap.bin"
   }
  },
  {
@@ -722,7 +722,7 @@
    "name": "ephysData.raw.lf",
    "created_by": null,
    "description": "Low Field band of raw neurophysiology data",
-   "filename_pattern": "*ephysData.raw*.lf.bin"
+   "filename_pattern": "*ephysData*.lf.bin"
   }
  },
   {
@@ -733,7 +733,7 @@
    "name": "ephysData.raw.meta",
    "created_by": null,
    "description": "Metadata text file for raw binary neurophysiology data",
-   "filename_pattern": "*ephysData.raw*.meta"
+   "filename_pattern": "*ephysData*.meta"
   }
  },
  {

--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -835,6 +835,28 @@
    "filename_pattern": "channels._phy_ids*.npy"
   }
  },
+  {
+  "model": "data.datasettype",
+  "pk": "d3547560-7cd3-48e6-903c-427317a06a3b",
+  "fields": {
+   "json": null,
+   "name": "_ibl_log.info",
+   "created_by": null,
+   "description": "Log File for normal job completion",
+   "filename_pattern": "_ibl_log.info*.log"
+  }
+ },
+  {
+  "model": "data.datasettype",
+  "pk": "86f168dc-5a37-4e67-adfe-353cf6aed751",
+  "fields": {
+   "json": null,
+   "name": "_ibl_log.error",
+   "created_by": null,
+   "description": "Log File for errored job",
+   "filename_pattern": "_ibl_log.error*.log"
+  }
+ },
  {
  "model": "data.datasettype",
  "pk": "8f36fa46-3fbc-4921-be8d-89f838c4ec42",

--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -736,6 +736,17 @@
    "filename_pattern": "*ephysData*.meta"
   }
  },
+   {
+  "model": "data.datasettype",
+  "pk": "05981c26-6f62-4bb6-af22-745f9751c7be",
+  "fields": {
+   "json": null,
+   "name": "ephysData.sync.npy",
+   "created_by": null,
+   "description": "Synchronization file for multi-probes acquisitions",
+   "filename_pattern": "*ephysData*.sync.npy"
+  }
+ },
  {
   "model": "data.datasettype",
   "pk": "41068334-1826-42ee-a09a-759d907dd0cf",

--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -301,10 +301,10 @@
   "pk": "74c0120c-7515-478f-9725-53d587d86c49",
   "fields": {
    "json": null,
-   "name": "wheel.timestamps",
+   "name": "wheel.times",
    "created_by": null,
    "description": "Timestamps for wheel timeseries",
-   "filename_pattern": "*wheel.timestamps.*"
+   "filename_pattern": "*wheel.times*"
   }
  },
  {
@@ -481,17 +481,6 @@
    "created_by": null,
    "description": "Time of feedback delivery (reward or not) in choiceworld - in absolute seconds, rather than relative to trial onset",
    "filename_pattern": "*trials.feedback_times.*"
-  }
- },
- {
-  "model": "data.datasettype",
-  "pk": "b396747f-0c67-4de4-9610-c7e210a5b86a",
-  "fields": {
-   "json": null,
-   "name": "wheel.times",
-   "created_by": null,
-   "description": "times of position in absolute seconds from session start",
-   "filename_pattern": "*wheel.times.*"
   }
  },
  {

--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -78,17 +78,6 @@
  },
  {
   "model": "data.datasettype",
-  "pk": "169323bd-7f91-4b75-a3e5-69530db33d21",
-  "fields": {
-   "json": null,
-   "name": "_iblrig_rightCamera.timestamps",
-   "created_by": null,
-   "description": "",
-   "filename_pattern": "_iblrig_rightCamera.timestamps.*"
-  }
- },
- {
-  "model": "data.datasettype",
   "pk": "26e731af-67a7-4be0-9dbc-c25eb153da31",
   "fields": {
    "json": null,
@@ -408,17 +397,6 @@
  },
  {
   "model": "data.datasettype",
-  "pk": "93b79e71-c8f6-4d81-b298-2c8f6aefe192",
-  "fields": {
-   "json": null,
-   "name": "_iblrig_bodyCamera.timestamps",
-   "created_by": null,
-   "description": "",
-   "filename_pattern": "_iblrig_bodyCamera.timestamps.*"
-  }
- },
- {
-  "model": "data.datasettype",
   "pk": "9464bcd6-be30-4180-876a-93625c79977d",
   "fields": {
    "json": null,
@@ -521,10 +499,10 @@
   "pk": "b5ec79de-9c9e-4009-8892-10aa2ddb9638",
   "fields": {
    "json": null,
-   "name": "_iblrig_leftCamera.timestamps",
+   "name": "_iblrig_Camera.timestamps",
    "created_by": null,
    "description": "",
-   "filename_pattern": "_iblrig_leftCamera.timestamps.*"
+   "filename_pattern": "_iblrig_*Camera.*timestamps*"
   }
  },
  {

--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -727,6 +727,17 @@
  },
   {
   "model": "data.datasettype",
+  "pk": "993e04d9-33f4-42c1-b665-3a39da26c72b",
+  "fields": {
+   "json": null,
+   "name": "ephysData.raw.nidq",
+   "created_by": null,
+   "description": "Nidq breakout box binary data for Neuropixel 3B system",
+   "filename_pattern": "*ephysData*.nidq.bin"
+  }
+ },
+  {
+  "model": "data.datasettype",
   "pk": "f9f6df39-52af-4818-a502-845489d671f4",
   "fields": {
    "json": null,

--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -301,7 +301,7 @@
   "pk": "74c0120c-7515-478f-9725-53d587d86c49",
   "fields": {
    "json": null,
-   "name": "wheel.times",
+   "name": "wheel.timestamps",
    "created_by": null,
    "description": "Timestamps for wheel timeseries",
    "filename_pattern": "*wheel.times*"

--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -67,6 +67,17 @@
  },
  {
   "model": "data.datasettype",
+  "pk": "6559486b-197a-49b4-abff-3efbc4a04ac7",
+  "fields": {
+   "json": null,
+   "name": "spikes.samples",
+   "created_by": null,
+   "description": "[nspi]. Sample index of spikes in their own electrophysiology binary file.",
+   "filename_pattern": "spikes.samples.npy"
+  }
+ },
+ {
+  "model": "data.datasettype",
   "pk": "156b266c-abc8-416d-96d4-db85fd232909",
   "fields": {
    "json": null,

--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -260,7 +260,7 @@
    "name": "_spikeglx_sync.channels",
    "created_by": null,
    "description": "[nsync]. Sync channel number (0-15)",
-   "filename_pattern": "_spikeglx_sync.channels*.npy"
+   "filename_pattern": "_spikeglx_sync.channel*.npy"
   }
  },
  {
@@ -304,7 +304,7 @@
    "name": "_spikeglx_sync.times",
    "created_by": null,
    "description": "[nsync]Times of sync pulses, seconds relative to ephys start",
-   "filename_pattern": "_spikeglx_sync.times*.npy"
+   "filename_pattern": "_spikeglx_sync.time*.npy"
   }
  },
  {
@@ -557,7 +557,7 @@
    "name": "_spikeglx_sync.polarities",
    "created_by": null,
    "description": "[nsync]. Polarity of front: 1: rising, -1 falling",
-   "filename_pattern": "_spikeglx_sync.polarities*.npy"
+   "filename_pattern": "_spikeglx_sync.polaritie*.npy"
   }
  },
  {

--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -741,10 +741,21 @@
   "pk": "05981c26-6f62-4bb6-af22-745f9751c7be",
   "fields": {
    "json": null,
-   "name": "ephysData.sync.npy",
+   "name": "ephysData.raw.sync",
    "created_by": null,
-   "description": "Synchronization file for multi-probes acquisitions",
+   "description": "Synchronization file for multi-probes acquisitions.",
    "filename_pattern": "*ephysData*.sync.npy"
+  }
+ },
+  {
+  "model": "data.datasettype",
+  "pk": "524bc84c-bf31-481f-b9f7-73e87090bd39",
+  "fields": {
+   "json": null,
+   "name": "ephysData.raw.wiring",
+   "created_by": null,
+   "description": "Description of wiring of synchronization auxiliaries",
+   "filename_pattern": "*ephysData*.wiring.json"
   }
  },
  {

--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -793,7 +793,7 @@
  },
  {
   "model": "data.datasettype",
-  "pk": "56403479-6530-436f-87d5-a1b8b5e1435e",
+  "pk": "f91db8df-ebdc-448a-9ba2-7b2d003f0c3d",
   "fields": {
    "json": null,
    "name": "clusters.probes",

--- a/alyx/data/transfers.py
+++ b/alyx/data/transfers.py
@@ -171,7 +171,7 @@ def globus_file_exists(file_record):
 
 def _filename_matches_pattern(filename, pattern):
     filename = op.basename(filename)
-    reg = pattern.replace('.', r'\.').replace('_', r'\_').replace('*', r'.+')
+    reg = pattern.replace('.', r'\.').replace('_', r'\_').replace('*', r'.*')
     return re.match(reg, filename, re.IGNORECASE)
 
 

--- a/scripts/oneoff/2019-10-04-DatasetTypes_DataMigration.py
+++ b/scripts/oneoff/2019-10-04-DatasetTypes_DataMigration.py
@@ -1,0 +1,34 @@
+from django.core.management import call_command
+from data.models import DatasetType, Dataset
+
+DRY = False
+
+dtypes_old2delte_reassign = [
+    # _iblrig_Camera.timestamps
+    ('93b79e71-c8f6-4d81-b298-2c8f6aefe192', 'b5ec79de-9c9e-4009-8892-10aa2ddb9638'),
+    # __iblrig_Camera.timestamps
+    ('169323bd-7f91-4b75-a3e5-69530db33d21', 'b5ec79de-9c9e-4009-8892-10aa2ddb9638'),
+    # _iblrig_Camera.raw
+    ('b3e9dded-027e-4cf0-8392-2baeb3bfcabd', 'e40899d0-a883-40ac-8214-344bcf249d09'),
+    # _iblrig_Camera.raw
+    ('df68dbb7-8d0e-4a5b-b829-e2a832a89b62', 'e40899d0-a883-40ac-8214-344bcf249d09'),
+]
+
+# load init fixtures
+call_command('loaddata',  './data/fixtures/data.dataformat.json')
+call_command('loaddata',  './data/fixtures/data.datasettype.json')
+
+for pks in dtypes_old2delte_reassign:
+    dt2del = DatasetType.objects.filter(pk=pks[0])
+    if not dt2del:
+        continue
+    # if we find any dataset reassign them to the proper one
+    datasets = Dataset.objects.filter(dataset_type=dt2del[0])
+    if len(datasets):
+        d2new = DatasetType.objects.get(pk=pks[1])
+        print(f'reassign {dt2del[0].name} to {d2new.name}')
+        if not DRY:
+            datasets.update(dataset_type=d2new)
+    print(f'delete {dt2del[0].name} ')
+    if not DRY:
+        dt2del.delete()

--- a/scripts/oneoff/2019-10-04-DatasetTypes_DataMigration.py
+++ b/scripts/oneoff/2019-10-04-DatasetTypes_DataMigration.py
@@ -30,9 +30,9 @@ for pks in dtypes_old2delte_reassign:
     datasets = Dataset.objects.filter(dataset_type=dt2del[0])
     if len(datasets):
         d2new = DatasetType.objects.get(pk=pks[1])
-        print(f'reassign {dt2del[0].name} to {d2new.name}')
+        print('reassign ' + dt2del[0].name + ' to ' + d2new.name)
         if not DRY:
             datasets.update(dataset_type=d2new)
-    print(f'delete {dt2del[0].name} ')
+    print('delete ' + dt2del[0].name)
     if not DRY:
         dt2del.delete()

--- a/scripts/oneoff/2019-10-04-DatasetTypes_DataMigration.py
+++ b/scripts/oneoff/2019-10-04-DatasetTypes_DataMigration.py
@@ -1,3 +1,5 @@
+""" `./manage.py shell < ../scripts/oneoff/2019-10-04-DatasetTypes_DataMigration.py` """
+
 from django.core.management import call_command
 from data.models import DatasetType, Dataset
 

--- a/scripts/oneoff/2019-10-04-DatasetTypes_DataMigration.py
+++ b/scripts/oneoff/2019-10-04-DatasetTypes_DataMigration.py
@@ -14,6 +14,8 @@ dtypes_old2delte_reassign = [
     ('b3e9dded-027e-4cf0-8392-2baeb3bfcabd', 'e40899d0-a883-40ac-8214-344bcf249d09'),
     # _iblrig_Camera.raw
     ('df68dbb7-8d0e-4a5b-b829-e2a832a89b62', 'e40899d0-a883-40ac-8214-344bcf249d09'),
+    # wheel.times
+    ('b396747f-0c67-4de4-9610-c7e210a5b86a', '74c0120c-7515-478f-9725-53d587d86c49'),
 ]
 
 # load init fixtures


### PR DESCRIPTION
- New fixtures for the electrophysiology data files.
- Bugfix on the file filter regex: star glob pattern represents zero to any number of character
- Bugfix on the sessions dataset type filters when a dataset type has several file instances in a session 
- Data migration script.

Release instructions: as usual with an extra step:
`./manage.py shell < ../scripts/oneoff/2019-10-04-DatasetTypes_DataMigration.py`
Squash merge planned on Monday morning