### PR TITLE
Update the backup/dump script

### DIFF
--- a/scripts/deployment_examples/01_backup_ibl.sh
+++ b/scripts/deployment_examples/01_backup_ibl.sh
@@ -4,17 +4,25 @@ mkdir -p "$backup_dir"
 # Full SQL dump.
 /usr/bin/pg_dump -cOx -U ibl_ro -h localhost ibl -f "$backup_dir/alyx_full.sql"
 gzip -f "$backup_dir/alyx_full.sql"
-
-# Full django JSON dump.
-source /var/www/alyx-main/venv/bin/activate
-python /var/www/alyx-main/alyx/manage.py dumpdata -e contenttypes -e auth.permission -e reversion.version -e reversion.revision -e admin.logentry --indent 1 > "$backup_dir/alyx_full.json"
-gzip -f "$backup_dir/alyx_full.json"
-
-# Send the files to the FlatIron server
 scp -P 61022 "$backup_dir/alyx_full.sql.gz" alyx@ibl.flatironinstitute.org:/mnt/ibl/json/$(date +%Y-%m-%d)_alyxfull.sql.gz
-#scp -P 61022 "$backup_dir/alyx_full.json.gz" alyx@ibl.flatironinstitute.org:/mnt/ibl/json/$(date +%Y-%m-%d)_alyxfull.json.gz
-scp -P 61022 "$backup_dir/alyx_full.json.gz" alyx@ibl.flatironinstitute.org:/mnt/ibl/json/alyxfull.json.gz
 
-# Human-readable TSV backup and Google Spreadsheets backup.
-# /var/www/alyx/alyx/bin/python /var/www/alyx/alyx/manage.py backup /var/www/alyx/alyx-backups/
+# Full django JSON dump, used by datajoint
+source /var/www/alyx-main/venv/bin/activate
+python /var/www/alyx-main/alyx/manage.py dumpdata \
+    -e contenttypes -e auth.permission \
+    -e reversion.version -e reversion.revision -e admin.logentry \
+    -e actions.ephyssession \
+    -e actions.notification \
+    -e actions.notificationrule \
+    -e actions.virusinjection \
+    -e data.download \
+    -e experiments.brainregion \
+    -e jobs.task \
+    -e misc.note \
+    -e subjects.subjectrequest \
+    --indent 1 -o "alyx_full.json"
+gzip -f "alyx_full.json"
+scp -P 61022 "alyx_full.json.gz" alyx@ibl.flatironinstitute.org:/mnt/ibl/json/alyxfull.json.gz
 
+# clean up the backups on AWS instance
+python /var/www/alyx-main/scripts/deployment_examples/99_purge_duplicate_backups.py


### PR DESCRIPTION
The updated script is only used at IBL at the moment (it's in scripts/deployment_examples).
This PR does the following

1. Disable all JSON daily backups (keeping only SQL backups)
2. Export an (overriden every day) JSON dump of the database taylored to datajoint needs (without a few tables they don't need)
3. Call the duplicate backups purging script
4. Remove the need for the `01b` daily script on the IBL server, which can be disabled

Should probably be deployed over a weekend to make sure the datajoint ingestion runs smoothly!