### PR TITLE
Exposed Dataset online prop

### DIFF
--- a/alyx/actions/serializers.py
+++ b/alyx/actions/serializers.py
@@ -98,7 +98,7 @@ class SessionDatasetsSerializer(serializers.ModelSerializer):
     class Meta:
         model = Dataset
         fields = ('id', 'name', 'dataset_type', 'data_url', 'url', 'file_size',
-                  'hash', 'version', 'collection')
+                  'hash', 'version', 'collection', 'online')
 
 
 class SessionWaterAdminSerializer(serializers.ModelSerializer):

--- a/alyx/data/serializers.py
+++ b/alyx/data/serializers.py
@@ -171,7 +171,7 @@ class DatasetSerializer(serializers.HyperlinkedModelSerializer):
                   'dataset_type', 'data_format', 'collection',
                   'session', 'file_size', 'hash', 'version',
                   'experiment_number', 'file_records',
-                  'subject', 'date', 'number')
+                  'subject', 'date', 'number', 'online')
         extra_kwargs = {
             'subject': {'write_only': True},
             'date': {'write_only': True},


### PR DESCRIPTION
I simply exposed the online dataset field in the datasets and Datasets and SessionDatasets serializers: https://github.com/cortex-lab/alyx/blob/72a0ba800dc9bf0946701a2ea6b805be04676ce1/alyx/data/models.py#L283-L289

If you think it's necessary we could add a field in the DatasetFileRecordsSerializer at the file record level:
```
def get_remote_accessible(self, obj):
    return (obj.data_url is not None and obj.exists and
            not obj.data_repository.globus_is_personal)
```

This should already suffice for filtering datasets that exist on FlatIron.