### PR TITLE
Register revisions

### DIFF
--- a/alyx/actions/tests_rest.py
+++ b/alyx/actions/tests_rest.py
@@ -206,7 +206,7 @@ class APIActionsTests(BaseTests):
         d = self.ar(self.client.get(reverse('session-list') + '?performance_lte=50'))
         self.assertEqual(d[0]['url'], s2['url'])
         self.assertTrue(len(d) == 1)
-        # test the Session serializer wateradmin related field
+        # test the Session serializer water admin related field
         ses = Session.objects.get(subject=self.subject, users=self.superuser,
                                   project=self.projectX, start_time__date='2018-07-09')
         WaterAdministration.objects.create(subject=self.subject, session=ses, water_administered=1)

--- a/alyx/alyx/urls.py
+++ b/alyx/alyx/urls.py
@@ -61,7 +61,7 @@ urlpatterns = [
     path('revisions', dv.RevisionList.as_view(),
          name="revision-list"),
 
-    path('revisions/<uuid:pk>', dv.RevisionDetail.as_view(),
+    path('revisions/<str:name>', dv.RevisionDetail.as_view(),
          name="revision-detail"),
 
     path('tags', dv.TagList.as_view(),

--- a/alyx/data/tests_rest.py
+++ b/alyx/data/tests_rest.py
@@ -441,6 +441,21 @@ class APIDataTests(BaseTests):
         self.assertTrue('#v1#' in r[0]['file_records'][0]['relative_path'])
         self.assertTrue('#v2#' in r[1]['file_records'][0]['relative_path'])
 
+        # Check error status with multiple revision folders
+        data = {'path': '%s/2018-01-01/002/#v1#' % self.subject,
+                'filenames': '#v2#/a.d.e1',
+                'name': 'drb2',  # this is the repository name
+        }
+        r = self.client.post(reverse('register-file'), data)
+        self.ar(r, 400)
+        # Check error status with subdirectories within revision folder
+        data = {'path': '%s/2018-01-01/002/dir2' % self.subject,
+                'filenames': '#v1#/alf/a.d.e1',
+                'name': 'drb2',  # this is the repository name
+                }
+        r = self.client.post(reverse('register-file'), data)
+        self.ar(r, 400)
+
     def test_register_with_tags(self):
         self.post(reverse('datarepository-list'), {'name': 'drb1', 'hostname': 'hostb1'})
         self.post(reverse('lab-list'), {'name': 'labb', 'repositories': ['drb1']})

--- a/alyx/data/transfers.py
+++ b/alyx/data/transfers.py
@@ -242,7 +242,6 @@ def _create_dataset_file_records(
     dataset, is_new = Dataset.objects.get_or_create(
         collection=collection, name=filename, session=session,
         dataset_type=dataset_type, data_format=data_format, revision=revision)
-
     dataset.default_dataset = default is True
     dataset.save()
 

--- a/alyx/data/transfers.py
+++ b/alyx/data/transfers.py
@@ -226,8 +226,8 @@ def _create_dataset_file_records(
         file_size=None, version=None, revision=None, default=None):
 
     assert session is not None
-    relative_path = op.join(rel_dir_path, collection or '', revision.name if revision
-                            else '', filename)
+    revision_name = f'#{revision.name}#' if revision else ''
+    relative_path = op.join(rel_dir_path, collection or '', revision_name, filename)
     dataset_type = get_dataset_type(filename)
     data_format = get_data_format(filename)
     assert dataset_type
@@ -243,10 +243,7 @@ def _create_dataset_file_records(
         collection=collection, name=filename, session=session,
         dataset_type=dataset_type, data_format=data_format, revision=revision)
 
-    if default:
-        dataset.default_dataset = True
-    else:
-        dataset.default_dataset = False
+    dataset.default_dataset = default is True
     dataset.save()
 
     # If the dataset already existed see if it is protected (i.e can't be overwritten)
@@ -265,7 +262,7 @@ def _create_dataset_file_records(
         dataset.version = version
     """
     if a hash/filesize is provided, label the dataset with it
-    if there was a hash and or filesize in the datset and the provided items are different,
+    if there was a hash and or filesize in the dataset and the provided items are different,
     then set the existing file records exists field to False
     If the hash doesn't exist and/or can't be verified, assume that the dataset is patched
     """

--- a/alyx/data/views.py
+++ b/alyx/data/views.py
@@ -409,7 +409,7 @@ class RegisterFileViewSet(mixins.CreateModelMixin,
         if isinstance(hashes, str):
             hashes = hashes.split(',')
 
-        # filesizes if provided
+        # file sizes if provided
         filesizes = request.data.get('filesizes', [None] * len(filenames))
         if isinstance(filesizes, str):
             filesizes = filesizes.split(',')
@@ -447,15 +447,12 @@ class RegisterFileViewSet(mixins.CreateModelMixin,
             subdirs = list(Path(fullpath[i:].strip('/')).parent.parts)
             # Check for revisions (folders beginning and ending with '#')
             is_rev = [x[0] + x[-1] == '##' for x in subdirs]
-            # There may be only 1 revision and it cannot contain sub folders
-            if sum(is_rev) > 1:
-                data = {'status_code': 400, 'detail': 'Multiple revision folders are not allowed'}
-                return Response(data=data, status=400)
-            elif sum(is_rev[:-1]):
-                data = {'status_code': 400,
-                        'detail': 'Revision folders cannot contain sub folders'}
-                return Response(data=data, status=400)
-            elif is_rev[-1]:
+            if any(is_rev):
+                # There may be only 1 revision and it cannot contain sub folders
+                if is_rev.index(True) != len(is_rev) - 1:
+                    data = {'status_code': 400,
+                            'detail': 'Revision folders cannot contain sub folders'}
+                    return Response(data=data, status=400)
                 revision, _ = Revision.objects.get_or_create(name=subdirs.pop().strip('#'))
             else:
                 revision = None

--- a/alyx/data/views.py
+++ b/alyx/data/views.py
@@ -120,6 +120,7 @@ class RevisionDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = Revision.objects.all()
     serializer_class = RevisionSerializer
     permission_classes = (permissions.IsAuthenticated,)
+    lookup_field = 'name'
 
 
 class TagList(generics.ListCreateAPIView):
@@ -350,10 +351,8 @@ class RegisterFileViewSet(mixins.CreateModelMixin,
               'filesizes': [145684, 354213],    # optional
               'server_only': True,   # optional, defaults to False. Will only create file
               # records in the server repositories and skips local repositories
-              'versions': ['1.4.4', '1.4.4'],  # optional,usually refers to the software version
+              'versions': ['1.4.4', '1.4.4'],  # optional, usually refers to the software version
               # used to generate the file
-              'revisions': ['v1', 'v2'] # optional, refers to the revision of dataset. Revision
-              must be represented in folder path of filename
               'default': False #optional , defaults to True, if more than one revision of dataset,
               whether to set current one as the default
               }
@@ -370,7 +369,6 @@ class RegisterFileViewSet(mixins.CreateModelMixin,
         If the dataset already exists, it will use the file hash to deduce if the file has been
         patched or not (ie. the filerecords will be created as not existing)
         """
-        filenames = request.data.get('filenames', ())
         user = request.data.get('created_by', None)
         if user:
             user = get_user_model().objects.get(username=user)
@@ -402,34 +400,22 @@ class RegisterFileViewSet(mixins.CreateModelMixin,
             filenames = filenames.split(',')
 
         # versions if provided
-        versions = request.data.get('versions', [None for f in filenames])
+        versions = request.data.get('versions', [None] * len(filenames))
         if isinstance(versions, str):
             versions = versions.split(',')
 
         # file hashes if provided
-        hashes = request.data.get('hashes', [None for f in filenames])
+        hashes = request.data.get('hashes', [None] * len(filenames))
         if isinstance(hashes, str):
             hashes = hashes.split(',')
 
         # filesizes if provided
-        filesizes = request.data.get('filesizes', [None for f in filenames])
+        filesizes = request.data.get('filesizes', [None] * len(filenames))
         if isinstance(filesizes, str):
             filesizes = filesizes.split(',')
 
         # flag to discard file records creation on local repositories, defaults to False
         server_only = request.data.get('server_only', False)
-
-        # revisions if provided
-        _revisions = request.data.get('revisions', [None for f in filenames])
-        if isinstance(_revisions, str):
-            _revisions = _revisions.split(',')
-        # Get the revision object from the revision name
-        revisions = []
-        for rev in _revisions:
-            if rev:
-                revisions.append(Revision.objects.get(name=rev))
-            else:
-                revisions.append(None)
 
         default = request.data.get('default', True)
         # Need to explicitly cast string to a bool
@@ -451,33 +437,31 @@ class RegisterFileViewSet(mixins.CreateModelMixin,
         assert session
 
         response = []
-        for filename, hash, fsize, version, revision in zip(filenames, hashes, filesizes, versions,
-                                                            revisions):
+        for filename, hash, fsize, version in zip(filenames, hashes, filesizes, versions):
             if not filename:
                 continue
-            # if filename contains path elements, interpret them as the collection field, otherwise
-            # collection field is None
-            collection = str(Path(filename.replace('\\', '/')).parent)
-            collection = None if collection == '.' else collection
-
-            # If the revision is specified need to check that the collection path doesn't contain
-            # the revision path too
-            if revision and collection:
-                # If the last part of the collection contains the revision collection we want to
-                # remove this from the collection
-                if Path(collection).parts[-1] == revision.name:
-                    collection = str(Path(*Path(collection).parts[:-1]))
-                    # case where all of collection is the revision
-                    collection = None if collection == '.' else collection
-                else:
-                    data = {'status_code': 400,
-                            'detail': ('Revision folder ' + str(Path(collection).parts[-1]) +
-                                       ' does not equal revision name "' + revision.name + '"')}
-                    return Response(data=data, status=400)
+            # Get collections/revisions for each file
+            fullpath = Path(rel_dir_path).joinpath(f).as_posix()
+            # Index of relative path (stuff after session path)
+            i = re.search(f'{subject}/{date}/{session_number:03}', fullpath).end()
+            subdirs = list(Path(fullpath[i:].strip('/')).parent.parts)
+            # Check for revisions (folders beginning and ending with '#')
+            is_rev = [x[0] + x[-1] == '##' for x in subdirs]
+            # There may be only 1 revision and it cannot contain sub folders
+            if sum(is_rev) > 1:
+                data = {'status_code': 400,
+                        'detail': 'Multiple revision folders are not allowed'}
+                return Response(data=data, status=400)
+            elif sum(is_rev[:-1]):
+                data = {'status_code': 400,
+                        'detail': 'Revision folders cannot contain sub folders'}
+                return Response(data=data, status=400)
+            revision = \
+                Revision.get_or_create(name=subdirs.pop().strip('#')) if is_rev[-1] else None
 
             filename = Path(filename).name
             dataset, resp = _create_dataset_file_records(
-                collection=collection, rel_dir_path=rel_dir_path, filename=filename,
+                collection='/'.join(subdirs), rel_dir_path=fullpath[:i], filename=filename,
                 session=session, user=user, repositories=repositories, exists_in=exists_in,
                 hash=hash, file_size=fsize, version=version, revision=revision, default=default)
             if resp:


### PR DESCRIPTION
- Revisions now extracted from file path, no longer provided as a separate field
- Revisions are defined as any directory within the session folder that starts and ends with a pound sign
- Error status is returned if either a revision folder contains a subfolder or there are multiple revisions
- There is no longer a difference between a collection in the path field and a collection within the filename
- Registering a file that already exists will not return an error status
- Can now get a revision record by name, i.e. `GET /revisions/<name>`