### PR TITLE
Data URL

### DIFF
--- a/alyx/data/tests.py
+++ b/alyx/data/tests.py
@@ -1,3 +1,15 @@
-# from django.test import TestCase
+from uuid import uuid4
 
-# Create your tests here.
+from django.test import TestCase
+
+from . import transfers
+
+
+class TransferUtilTests(TestCase):
+    def test_add_uuid_to_filename(self):
+        uuid = uuid4()
+        expected = f'spikes.times.{uuid}.npy'
+        testable = transfers._add_uuid_to_filename('spikes.times.npy', uuid)
+        self.assertEqual(expected, testable)
+        # Check leaves UUID if already added
+        self.assertEqual(expected, transfers._add_uuid_to_filename(testable, uuid))

--- a/alyx/data/transfers.py
+++ b/alyx/data/transfers.py
@@ -104,6 +104,8 @@ def _incomplete_dataset_ids():
 
 
 def _add_uuid_to_filename(fn, uuid):
+    if str(uuid) in fn:
+        return fn
     dpath, ext = op.splitext(fn)
     return dpath + '.' + str(uuid) + ext
 


### PR DESCRIPTION
If a file record relative path already contains a UUID, don't add one