### PR TITLE
TABLES_ROOT S3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
   - export PIP_USE_MIRRORS=true
 install:
   - pip install -r requirements.txt
+  - pip install pyarrow  # For one_cache tests
 before_script:
   - psql -c "CREATE DATABASE travisci;" -U postgres
 script:

--- a/alyx/alyx/settings_secret_template.py
+++ b/alyx/alyx/settings_secret_template.py
@@ -4,6 +4,8 @@
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = '%SECRET_KEY%'
 
+S3_ACCESS = {}  # should include the keys (access_key, secret_key, region)
+
 # Database
 # https://docs.djangoproject.com/en/1.9/ref/settings/#databases
 

--- a/alyx/alyx/settings_template.py
+++ b/alyx/alyx/settings_template.py
@@ -245,8 +245,9 @@ MEDIA_ROOT = os.path.realpath(os.path.join(BASE_DIR, '../uploaded/'))
 MEDIA_ROOT = '/backups/uploaded/'
 MEDIA_URL = '/uploaded/'
 
+# The location for saving and/or serving the cache tables.
+# May be a local path, http address or s3 uri (i.e. s3://)
 TABLES_ROOT = os.path.realpath(os.path.join(BASE_DIR, '../tables/'))
-TABLES_ROOT = '/backups/tables/'
 
 UPLOADED_IMAGE_WIDTH = 800
 

--- a/alyx/data/transfers.py
+++ b/alyx/data/transfers.py
@@ -165,7 +165,7 @@ def globus_file_exists(file_record):
     name_uuid = _add_uuid_to_filename(name, file_record.dataset.pk)
     try:
         existing = tc.operation_ls(file_record.data_repository.globus_endpoint_id, path=dir_path)
-    except globus_sdk.exc.TransferAPIError as e:
+    except globus_sdk.exc.GlobusError as e:
         logger.warning(e)
         return False
     for existing_file in existing:
@@ -303,7 +303,7 @@ def iter_registered_directories(data_repository=None, tc=None, path=None):
     path = path or data_repository.path
     try:
         contents = tc.operation_ls(data_repository.globus_endpoint_id, path=path)
-    except globus_sdk.exc.TransferAPIError as e:
+    except globus_sdk.exc.GlobusError as e:
         logger.warning(e)
         return
     contents = contents['DATA']
@@ -451,7 +451,7 @@ def bulk_sync(dry_run=False, lab=None, gc=None, check_mismatch=False):
             try:
                 print(str(c) + '/' + str(nfiles) + ' ls ' + cpath + ' on ' + str(_last_ep))
                 ls_result = gc.operation_ls(_last_ep, path=_last_path)
-            except globus_sdk.exc.TransferAPIError:
+            except globus_sdk.exc.GlobusError:
                 ls_result = []
         # compare the current file against the ls list, update the file_size if necessary
         exists = False
@@ -660,7 +660,7 @@ def globus_delete_local_datasets(datasets, dry=True, gc=None):
                 path = Path(_filename_from_file_record(file_record, add_uuid=add_uuid))
                 ls_obj = gtc.operation_ls(file_record.data_repository.globus_endpoint_id,
                                           path=path.parent)
-            except globus_sdk.exc.TransferAPIError as err:
+            except globus_sdk.exc.GlobusError as err:
                 logger.warning('Globus error trial %i/%i', ntry + 1, N_RETRIES, exc_info=err)
                 if 'ClientError.NotFound' in str(err):
                     return
@@ -796,7 +796,7 @@ def globus_delete_file_records(file_records, dry=True, gc=None):
                     try:
                         ls_current_path = [f['name'] for f in
                                            gtc.operation_ls(ge, path=current_path)]
-                    except globus_sdk.exc.TransferAPIError as err:
+                    except globus_sdk.exc.GlobusError as err:
                         if 'ClientError.NotFound' in str(err):
                             logger.warning('DIR NOT FOUND: ' + file2del + ' on ' +
                                            str(fr.data_repository.name))

--- a/alyx/data/transfers.py
+++ b/alyx/data/transfers.py
@@ -165,7 +165,7 @@ def globus_file_exists(file_record):
     name_uuid = _add_uuid_to_filename(name, file_record.dataset.pk)
     try:
         existing = tc.operation_ls(file_record.data_repository.globus_endpoint_id, path=dir_path)
-    except globus_sdk.exc.GlobusError as e:
+    except globus_sdk.TransferAPIError as e:
         logger.warning(e)
         return False
     for existing_file in existing:
@@ -303,7 +303,7 @@ def iter_registered_directories(data_repository=None, tc=None, path=None):
     path = path or data_repository.path
     try:
         contents = tc.operation_ls(data_repository.globus_endpoint_id, path=path)
-    except globus_sdk.exc.GlobusError as e:
+    except globus_sdk.TransferAPIError as e:
         logger.warning(e)
         return
     contents = contents['DATA']
@@ -451,7 +451,7 @@ def bulk_sync(dry_run=False, lab=None, gc=None, check_mismatch=False):
             try:
                 print(str(c) + '/' + str(nfiles) + ' ls ' + cpath + ' on ' + str(_last_ep))
                 ls_result = gc.operation_ls(_last_ep, path=_last_path)
-            except globus_sdk.exc.GlobusError:
+            except globus_sdk.TransferAPIError:
                 ls_result = []
         # compare the current file against the ls list, update the file_size if necessary
         exists = False
@@ -660,7 +660,7 @@ def globus_delete_local_datasets(datasets, dry=True, gc=None):
                 path = Path(_filename_from_file_record(file_record, add_uuid=add_uuid))
                 ls_obj = gtc.operation_ls(file_record.data_repository.globus_endpoint_id,
                                           path=path.parent)
-            except globus_sdk.exc.GlobusError as err:
+            except globus_sdk.TransferAPIError as err:
                 logger.warning('Globus error trial %i/%i', ntry + 1, N_RETRIES, exc_info=err)
                 if 'ClientError.NotFound' in str(err):
                     return
@@ -796,7 +796,7 @@ def globus_delete_file_records(file_records, dry=True, gc=None):
                     try:
                         ls_current_path = [f['name'] for f in
                                            gtc.operation_ls(ge, path=current_path)]
-                    except globus_sdk.exc.GlobusError as err:
+                    except globus_sdk.TransferAPIError as err:
                         if 'ClientError.NotFound' in str(err):
                             logger.warning('DIR NOT FOUND: ' + file2del + ' on ' +
                                            str(fr.data_repository.name))

--- a/alyx/misc/management/commands/one_cache.py
+++ b/alyx/misc/management/commands/one_cache.py
@@ -235,7 +235,7 @@ class Command(BaseCommand):
                 # Write cache info json to s3
                 logger.debug(f'Opening output stream to {tag_file}')
                 with s3.open_output_stream(tag_file) as stream:
-                    stream.writelines(json.dumps(metadata, indent=1))
+                    stream.writelines(json.dumps(metadata, indent=1).encode())
                 # Write zip file to s3
                 logger.debug(f'Opening output stream to {zip_file}')
                 with s3.open_output_stream(zip_file) as stream:

--- a/alyx/misc/management/commands/one_cache.py
+++ b/alyx/misc/management/commands/one_cache.py
@@ -235,7 +235,7 @@ class Command(BaseCommand):
                 # Write cache info json to s3
                 logger.debug(f'Opening output stream to {tag_file}')
                 with s3.open_output_stream(tag_file) as stream:
-                    stream.writelines(json.dumps(metadata, indent=1).encode())
+                    stream.write(json.dumps(metadata, indent=1).encode())
                 # Write zip file to s3
                 logger.debug(f'Opening output stream to {zip_file}')
                 with s3.open_output_stream(zip_file) as stream:

--- a/alyx/misc/management/commands/one_cache.py
+++ b/alyx/misc/management/commands/one_cache.py
@@ -108,7 +108,7 @@ def _save(filename: str, df: pd.DataFrame, metadata: dict = None, dry=False) -> 
         elif parsed.scheme == '':
             pq.write_table(table, filename)
         else:
-            raise ValueError(f'Unsupported URI "{parsed.scheme}"')
+            raise ValueError(f'Unsupported URI scheme "{parsed.scheme}"')
     return table
 
 
@@ -242,7 +242,7 @@ class Command(BaseCommand):
                 with open(zip_file, 'wb') as fid:
                     fid.write(zip_buffer.getbuffer())
             else:
-                raise ValueError(f'Unsupported URI "{scheme}"')
+                raise ValueError(f'Unsupported URI scheme "{scheme}"')
         finally:
             zip_buffer.close()
         return zip_file, tag_file

--- a/alyx/misc/management/commands/one_cache.py
+++ b/alyx/misc/management/commands/one_cache.py
@@ -228,14 +228,16 @@ class Command(BaseCommand):
         scheme = parsed.scheme or 'file'
         try:
             if scheme == 's3':
-                zip_file = f'{parsed.path.strip("/")}/{ZIP_NAME}'
-                tag_file = f'{parsed.path.strip("/")}/{META_NAME}'
+                zip_file = f'{parsed.netloc}/{parsed.path.strip("/")}/{ZIP_NAME}'
+                tag_file = f'{parsed.netloc}/{parsed.path.strip("/")}/{META_NAME}'
                 s3 = _s3_filesystem()
                 metadata['location'] = _get_s3_virtual_host(zip_file, s3.region)  # Add URL
                 # Write cache info json to s3
+                logger.debug(f'Opening output stream to {tag_file}')
                 with s3.open_output_stream(tag_file) as stream:
                     stream.writelines(json.dumps(metadata, indent=1))
                 # Write zip file to s3
+                logger.debug(f'Opening output stream to {zip_file}')
                 with s3.open_output_stream(zip_file) as stream:
                     stream.write(zip_buffer.getbuffer())
             elif scheme == 'file':

--- a/alyx/misc/management/commands/one_cache.py
+++ b/alyx/misc/management/commands/one_cache.py
@@ -185,7 +185,8 @@ class Command(BaseCommand):
         :param dry: If True, does not actually write to disk
         :return: A PyArrow table and the full path to the saved file
         """
-        logger.info(f'Saving table "{name}" to {self.dst_dir}...')
+        if not kwargs.get('dry'):
+            logger.info(f'Saving table "{name}" to {self.dst_dir}...')
         scheme = urllib.parse.urlparse(self.dst_dir).scheme or 'file'
         if scheme == 'file':
             Path(self.dst_dir).mkdir(exist_ok=True)
@@ -227,8 +228,8 @@ class Command(BaseCommand):
         scheme = parsed.scheme or 'file'
         try:
             if scheme == 's3':
-                zip_file = f'{parsed.path}/{ZIP_NAME}'
-                tag_file = f'{parsed.path}/{META_NAME}'
+                zip_file = f'{parsed.path.strip("/")}/{ZIP_NAME}'
+                tag_file = f'{parsed.path.strip("/")}/{META_NAME}'
                 s3 = _s3_filesystem()
                 metadata['location'] = _get_s3_virtual_host(zip_file, s3.region)  # Add URL
                 # Write cache info json to s3


### PR DESCRIPTION
* TABLES_ROOT may be an S3 URI, e.g. `s3://my-bucket-name/dst/dir`.
* The cache/info endpoint will read the remote s3 cache_info.json file if TABLES_ROOT is a URL.
* The cache.zip endpoint will return an HTTP redirect if the TABLES_ROOT location is not local, however the API doesn't support this as the URL parameters are no longer valid for external URLs.
* The cache generation now has a compress option which is required to save a zip file.  If set, the tables are compressed in memory and written to a zip file.  
* When compress flag is set the tables are written to a temp directory before compression.
* generate_cache now supports an S3 TABLES_ROOT URI.  Tables are directly written to S3 using the pyarrow FileSystem API, which does not require extra dependencies.