### PR TITLE
Dataset delete protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ this setup will work on other systems. Assumptions made are that you have sudo p
 * alyx-dev is sync with the **dev** branch
 * Migrations files are provided by the repository
 * Continuous integration is setup, to run tests locally:
-    -   `./manage.py test -n` test without migrations (faster)
-    -   `./manage.py test` test with migrations (recommended if model changes)
+    - `./manage.py test -n` test without migrations (faster)
+    - `./manage.py test` test with migrations (recommended if model changes)
+    - NB: When running tests ensure `DEBUG = True` in the settings.py file (specifically `SECURE_SSL_REDIRECT = True` causes REST tests to fail)
 
 ```
 $ /manage.py test -n

--- a/alyx/data/tests.py
+++ b/alyx/data/tests.py
@@ -57,4 +57,3 @@ class TestDatasetTypeModel(TestCase):
         for filename, dataname in filename_typename:
             with self.subTest(filename=filename):
                 self.assertEqual(get_dataset_type(filename).name, dataname)
-

--- a/alyx/data/tests_rest.py
+++ b/alyx/data/tests_rest.py
@@ -184,6 +184,19 @@ class APIDataTests(BaseTests):
         self.ar(r, 201)
         self.assertEqual(r.data['default_dataset'], False)
 
+        # Create protected tag and dataset
+        r = self.ar(self.post(reverse('tag-list'), {'name': 'foo_tag', 'protected': True}), 201)
+        data = {'name': 'foo.bar', 'dataset_type': 'dst', 'created_by': 'test',
+                'data_format': 'df', 'date': '2018-01-01', 'number': 2, 'subject': self.subject,
+                'tags': [r['name']]}
+
+        r = self.ar(self.post(reverse('dataset-list'), data), 201)
+        did = r['url'].split('/')[-1]
+
+        # Now attempt to delete the protected dataset
+        r = self.client.delete(reverse('dataset-detail', args=[did]), data)
+        self.assertRegex(self.ar(r, 403), 'protected')
+
     def test_dataset_date_filter(self):
         # create 2 datasets with different dates
         data = {

--- a/alyx/data/views.py
+++ b/alyx/data/views.py
@@ -232,11 +232,8 @@ class DatasetDetail(generics.RetrieveUpdateDestroyAPIView):
             return super().delete(request, *args, **kwargs)
         except models.ProtectedError as e:
             # Return Forbidden response with dataset name and list of protected tags associated
-            tags = e.protected_objects.tags.filter(protected=True).values_list('name', flat=True)
-            tags_str = '"' + '", "'.join(tags) + '"'
-            return Response(
-                f'Dataset {e.protected_objects.name} is protected by the tag(s) {tags_str}', 403
-            )
+            err_msg, _ = e.args
+            return Response(e.args[0], 403)
 
 
 # FileRecord


### PR DESCRIPTION
* ProtectedError raised when attempting to delete Datasets that are associated with protected tags
* Dataset view returns 403 under these circumstances
* Admin interface shows error message (although I couldn't get rid of the success message)
* force flag to override protected error in model delete and query set delete methods