### PR TITLE
Fix failing autoname when new nickname already exists

### DIFF
--- a/alyx/subjects/models.py
+++ b/alyx/subjects/models.py
@@ -630,7 +630,11 @@ class Line(BaseModel):
     def new_subject_autoname(self):
         self.subject_autoname_index = self.subject_autoname_index + 1
         self.save()
-        return '%s_%04d' % (self.nickname, self.subject_autoname_index)
+        new_name = '%s_%04d' % (self.nickname, self.subject_autoname_index)
+        if Subject.objects.filter(nickname=new_name).count() > 0:
+            return self.new_subject_autoname()
+        assert Subject.objects.filter(nickname=new_name).count() == 0
+        return new_name
 
     def set_autoname(self, obj):
         if isinstance(obj, BreedingPair):


### PR DESCRIPTION
Fixing a bug reported by Charu today:

> We are getting a 'server error 500' when trying to add animals to a litter for a specific breeding pair:
Home -> litters -> (filter by line) Ai32cg x PVCre  -> click on  Ai32cg.Pv_L_053 -> now try to add any sex and save and we get the error.

The autoname logic was failing because the new nickname already existed. This fix just iterates the autoname until the new nickname doesn't already exist.