### PR TITLE
manual label dataset types

### DIFF
--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -1758,5 +1758,27 @@
       "description": "All trials data for a given subject, contains the same columns as trials.table, plus \"session\", \"session_start_time\" and \"session_number\"",
       "filename_pattern": ""
     }
+  },
+  {
+    "model": "data.datasettype",
+    "pk": "479ea451-e7d5-413a-8dc1-e8eb44e5afc2",
+    "fields": {
+      "json": null,
+      "name": "_ibl_videoTracking.trainingDataPaw",
+      "created_by": null,
+      "description": "Manual labels of the paws for training pose estimation algorithms. Contains csv files with labels, frame images and short video snippets from various sessions",
+      "filename_pattern": ""
+    }
+  },
+  {
+    "model": "data.datasettype",
+    "pk": "4ef9e5ed-c132-4329-a9b0-63260c26ccac",
+    "fields": {
+      "json": null,
+      "name": "_ibl_videoTracking.trainingDataPupil",
+      "created_by": null,
+      "description": "Manual labels of the pupils for training pose estimation algorithms. Contains csv files with labels, frame images and short video snippets from various sessions",
+      "filename_pattern": ""
+    }
   }
 ]


### PR DESCRIPTION
Dataset types required to register label archives for LightningPose paper, as discussed in DAWG 09/03/2023