### PR TITLE
Extend zygosity filters

### DIFF
--- a/alyx/subjects/admin.py
+++ b/alyx/subjects/admin.py
@@ -126,16 +126,26 @@ class ZygosityFilter(DefaultListFilter):
             (None, 'All'),
             ('p', 'All positive'),
             ('h', 'All homo'),
+            ('n', 'All negative'),
+            ('e', 'All het')
         )
 
     def queryset(self, request, queryset):
         if self.value() is None:
             return queryset.all()
-        elif self.value() in ('p', 'h'):
+        elif self.value() in ('p', 'h', 'n', 'e'):
             # Only keep subjects with a non-null geontype.
             queryset = queryset.filter(genotype__isnull=False).distinct()
-            # Exclude subjects that have a specific zygosity/
-            d = dict(zygosity=0) if self.value() == 'p' else dict(zygosity__in=(0, 1, 3))
+            # Exclude subjects that have a specific zygosity
+            # See alyx/alyx/subjects/models.py - ZYGOSITY_TYPES for explanation
+            if self.value() == 'p':
+                d = dict(zygosity=0)
+            elif self.value() == 'h':
+                d = dict(zygosity__in=(0, 1, 3))
+            elif self.value() == 'n':
+                d = dict(zygosity__in=(1, 2, 3))
+            else:
+                d = dict(zygosity__in=(0, 2, 3))
             nids = set([z.subject.id.hex for z in Zygosity.objects.filter(**d)])
             return queryset.exclude(pk__in=nids)
 


### PR DESCRIPTION
## Goal of PR
In reference to issue #809 and pull request #815, I've extended the zygosity filter functionality to accommodate requests to see mice with either negative or heterozygous zygosity. 

## Explanation of changes
Since this is my first contribution to Alyx, I'll explain what I did just in case I made an error.

Using the `ZYGOSITY_TYPES` (found [here](https://github.com/cortex-lab/alyx/blob/08f0fe7ebe1c5b0ad6ea2ff23ad229845aad4666/alyx/subjects/models.py#L27)), I added two options to the zygosity filter. 

The `lookups` now include 'n' and 'e' for 'negative' and 'heterozygous', respectively:
```python
   def lookups(self, request, model_admin):
        return (
            (None, 'All'),
            ('p', 'All positive'),
            ('h', 'All homo'),
            ('n', 'All negative'),
            ('e', 'All het')
        )
```

Additionally, `queryset()` was modified to the following. I'm not sure why the dictionary is created with a different key name, other than to indicate that whether the zygosity to remove has one value or multiple. Also, the list of zygosities to remove are based on `ZYGOSITY_TYPES` that I linked to above. 
```python
def queryset(self, request, queryset):
      if self.value() is None:
          return queryset.all()
      elif self.value() in ('p', 'h', 'n', 'e'):
          # Only keep subjects with a non-null geontype.
          queryset = queryset.filter(genotype__isnull=False).distinct()
          # Exclude subjects that have a specific zygosity
          # See alyx/alyx/subjects/models.py - ZYGOSITY_TYPES for explanation
          if self.value() == 'p':
              d = dict(zygosity=0)
          elif self.value() == 'h':
              d = dict(zygosity__in=(0, 1, 3))
          elif self.value() == 'n':
              d = dict(zygosity__in=(1, 2, 3))
          else:
              d = dict(zygosity__in=(0, 2, 3))
          nids = set([z.subject.id.hex for z in Zygosity.objects.filter(**d)])
          return queryset.exclude(pk__in=nids)
```