### PR TITLE
Release/2.1.2

### DIFF
--- a/alyx/actions/tests.py
+++ b/alyx/actions/tests.py
@@ -170,7 +170,7 @@ class NotificationTests(TestCase):
         date = timezone.datetime(2018, 6, 3, 16, 0, 0)
         check_water_administration(self.subject, date=date)
         notif = Notification.objects.last()
-        self.assertTrue(notif is None)
+        self.assertIsNone(notif)
 
     def test_notif_water_2(self):
         # If the last water admin was on June 3 at 12pm, the notification
@@ -181,6 +181,14 @@ class NotificationTests(TestCase):
             check_water_administration(self.subject, date=date)
             notif = Notification.objects.last()
             self.assertTrue((notif is not None) is r)
+
+    def test_notif_water_3(self):
+        # If the subject was place on water restriction on the same day
+        # there should be no notification
+        date = timezone.datetime(2018, 6, 2, 22, 30, 0)
+        check_water_administration(self.subject, date=date)
+        notif = Notification.objects.last()
+        self.assertIsNone(notif)
 
     def test_notif_user_change_1(self):
         self.subject.responsible_user = self.user2

--- a/alyx/alyx/__init__.py
+++ b/alyx/alyx/__init__.py
@@ -1,1 +1,1 @@
-VERSION = __version__ = '2.1.1'
+VERSION = __version__ = '2.1.2'

--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -2294,8 +2294,19 @@
       "json": null,
       "name": "passingSpikes.table",
       "created_by": null,
-      "description": "A compressed table containing only the spikes belonging to passing units, to accelarate data loading",
-      "filename_pattern": "*passingspikes.table*"
+      "description": "A compressed table containing only the spikes belonging to passing units, to accelerate data loading.",
+      "filename_pattern": ""
+    }
+  },
+  {
+    "model": "data.datasettype",
+    "pk": "5137d09a-41b6-435f-aba5-c4a7e2b0d240",
+    "fields": {
+      "json": null,
+      "name": "rawImagingData.times",
+      "created_by": null,
+      "description": "The raw frame exposure times.",
+      "filename_pattern": ""
     }
   }
 ]

--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -78,6 +78,6 @@ tqdm==4.66.4
 typing_extensions==4.12.2
 tzdata==2024.1
 uritemplate==4.1.1
-urllib3==1.26.18
+urllib3==1.26.19
 webdavclient3==3.14.6
 zipp==3.19.2


### PR DESCRIPTION
## Release notes
### fixtures
- passingSpikes.table dataset type
- rawImagingData.times dataset type
### system
- bump urllib version
- only notify users of missing weight and water after first day of water restriction

Release steps below:

## Pull the changes from github

## 1) Activate environment, cd to the alyx folder and install requirements
git stash
git pull
git stash pop

## 2) Activate environment - install requirements (if new packages)
pip install -r requirements_frozen.txt


## 3) Update the database if any scheme changes - we expect no migrations
cd alyx
./manage.py makemigrations
./manage.py migrate

## 4) If new fixtures load in the database:
../scripts/load-init-fixtures.sh

## 5) if new tables change the postgres permissions
./manage.py set_db_permissions
./manage.py set_user_permissions

## 6) If updates to django version
./manage.py collectstatic

## 7) Restart the Apache server
sudo service apache2 restart
