### PR TITLE
3.1.3

### DIFF
--- a/alyx/actions/fixtures/actions.watertype.json
+++ b/alyx/actions/fixtures/actions.watertype.json
@@ -54,5 +54,13 @@
   "json": null,
   "name": "Hydrogel"
  }
+},
+{
+ "model": "actions.watertype",
+ "pk": "dba3e45a-fb95-4a6d-9140-2b704c5b300e",
+ "fields": {
+  "json": null,
+  "name": "Water 1% Citric Acid"
+ }
 }
 ]

--- a/alyx/actions/serializers.py
+++ b/alyx/actions/serializers.py
@@ -48,7 +48,6 @@ class BaseActionSerializer(serializers.HyperlinkedModelSerializer):
         slug_field='username',
         queryset=get_user_model().objects.all(),
         required=False,
-        default=serializers.CurrentUserDefault(),
     )
 
     location = serializers.SlugRelatedField(
@@ -57,7 +56,6 @@ class BaseActionSerializer(serializers.HyperlinkedModelSerializer):
         queryset=LabLocation.objects.all(),
         allow_null=True,
         required=False,
-
     )
 
     procedures = serializers.SlugRelatedField(
@@ -75,6 +73,11 @@ class BaseActionSerializer(serializers.HyperlinkedModelSerializer):
         queryset=Lab.objects.all(),
         many=False,
         required=False,)
+
+    def create(self, validated_data):
+        if not validated_data.get('users'):
+            validated_data['users'] = [self.context['request'].user]
+        return super().create(validated_data)
 
 
 class LabLocationSerializer(serializers.ModelSerializer):

--- a/alyx/alyx/__init__.py
+++ b/alyx/alyx/__init__.py
@@ -1,1 +1,1 @@
-VERSION = __version__ = '3.1.2'
+VERSION = __version__ = '3.1.3'

--- a/alyx/alyx/base.py
+++ b/alyx/alyx/base.py
@@ -382,6 +382,7 @@ class BaseAdmin(VersionAdmin):
         # [CR 2024-03-12]
         # HACK: following a request by Charu R from cortexlab, we authorize all users in the
         # special Husbandry group to edit litters.
+        # FIXME This should be moved to the individual model admin has_change_permission methods
         husbandry = 'husbandry' in ', '.join(_.name.lower() for _ in request.user.groups.all())
         if husbandry:
             if obj.__class__.__name__ in ('Litter', 'Subject', 'BreedingPair'):

--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -2327,8 +2327,8 @@
       "json": null,
       "name": "fpData.digitalInputs",
       "created_by": null,
-      "description": "",
-      "filename_pattern": "*digitalInputs.raw*"
+      "description": "Parquet or CSV file output by Bonsai containing the synchronisation TTLs",
+      "filename_pattern": "*_fpData.digitalInputs.*"
     }
   }
 ]

--- a/alyx/data/fixtures/data.datasettype.json
+++ b/alyx/data/fixtures/data.datasettype.json
@@ -579,7 +579,7 @@
       "name": "_iblrig_taskData.raw",
       "created_by": null,
       "description": "Data file saved by PyBpod in json serializable lines (file itself is not a json object, each line is a json object corresponding to a trial) - Training task w/ automated contrast",
-      "filename_pattern": "_iblrig_taskData.raw.*"
+      "filename_pattern": "_*_taskData.raw.*"
     }
   },
   {
@@ -589,7 +589,7 @@
       "json": null,
       "name": "passiveWhiteNoise.times",
       "created_by": null,
-      "description": "Times of white noise bursts, equivilent to the negative feedback sound during the choice world task",
+      "description": "Times of white noise bursts, equivalent to the negative feedback sound during the choice world task",
       "filename_pattern": "*passiveWhiteNoise.times.*"
     }
   },
@@ -1799,7 +1799,7 @@
       "json": null,
       "name": "subjectTrials.table",
       "created_by": null,
-      "description": "All trials data for a given subject, contains the same columns as trials.table, plus \"session\", \"session_start_time\" and \"session_number\"",
+      "description": "All trials data for a given subject, contains the same columns as _ibl_trials.table, plus additional trials data: \"goCueTrigger_times\", \"stimOnTrigger_times\", \"stimFreezeTrigger_times\", \"stimFreeze_times\", \"stimOffTrigger_times\", \"stimOff_times\", \"phase\", \"position\", \"quiescence\". The following are session meta data columns: \"session\", \"session_start_time\" and \"task_protocol\", \"protocol_number\"",
       "filename_pattern": ""
     }
   },
@@ -2327,8 +2327,19 @@
       "json": null,
       "name": "fpData.digitalInputs",
       "created_by": null,
-      "description": "Parquet or CSV file output by Bonsai containing the synchronisation TTLs",
+      "description": "Parquet or CSV file output by Bonsai containing the synchronisation TTLs.",
       "filename_pattern": "*_fpData.digitalInputs.*"
+    }
+  },
+  {
+    "model": "data.datasettype",
+    "pk": "a94ba7c4-9260-4270-98c0-96030248a7b6",
+    "fields": {
+      "json": null,
+      "name": "_sp_video.times",
+      "created_by": null,
+      "description": "An array of passive video frame times, where each column represents a repeat of the video.",
+      "filename_pattern": "_sp_video.times.*"
     }
   }
 ]

--- a/alyx/experiments/serializers.py
+++ b/alyx/experiments/serializers.py
@@ -5,16 +5,22 @@ from experiments.models import (ProbeInsertion, TrajectoryEstimate, ProbeModel, 
                                 Channel, BrainRegion, ChronicInsertion, FOV, FOVLocation,
                                 ImagingType, ImagingStack)
 from data.models import DatasetType, Dataset, DataRepository, FileRecord
-from subjects.models import Subject
+from subjects.models import Subject, Project
 from misc.models import Lab
 
 
 class SessionListSerializer(serializers.ModelSerializer):
 
+    projects = serializers.SlugRelatedField(read_only=False,
+                                            slug_field='name',
+                                            queryset=Project.objects.all(),
+                                            many=True)
+
     @staticmethod
     def setup_eager_loading(queryset):
         """ Perform necessary eager loading of data to avoid horrible performance."""
         queryset = queryset.select_related('subject', 'lab')
+        queryset = queryset.prefetch_related('projects')
         return queryset.order_by('-start_time')
 
     subject = serializers.SlugRelatedField(read_only=True, slug_field='nickname')
@@ -22,7 +28,7 @@ class SessionListSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Session
-        fields = ('subject', 'start_time', 'number', 'lab', 'id', 'task_protocol')
+        fields = ('subject', 'start_time', 'number', 'lab', 'id', 'projects', 'task_protocol')
 
 
 class TrajectoryEstimateSerializer(serializers.ModelSerializer):

--- a/alyx/experiments/urls.py
+++ b/alyx/experiments/urls.py
@@ -17,5 +17,6 @@ urlpatterns = [
     path('fields-of-view', ev.FOVList.as_view(), name="fieldsofview-list"),
     path('fields-of-view/<uuid:pk>', ev.FOVDetail.as_view(), name="fieldsofview-detail"),
     path('fov-location', ev.FOVLocationList.as_view(), name="fovlocation-list"),
+    path('fov-location/<uuid:pk>', ev.FOVLocationDetail.as_view(), name="fovlocation-detail"),
     path('imaging-stack', ev.ImagingStackList.as_view(), name="imagingstack-list"),
     path('imaging-stack/<uuid:pk>', ev.ImagingStackDetail.as_view(), name="imagingstack-detail")]

--- a/alyx/experiments/views.py
+++ b/alyx/experiments/views.py
@@ -174,8 +174,8 @@ class ProbeInsertionDetail(generics.RetrieveUpdateDestroyAPIView):
 
 
 class ChronicInsertionFilter(BaseFilterSet):
-    subject = CharFilter('session__subject__nickname')
-    lab = CharFilter('session__lab__name')
+    subject = CharFilter('subject__nickname')
+    lab = CharFilter('lab__name')
     model = CharFilter('model__name')
     probe = UUIDFilter('probe_insertion__id')
     session = UUIDFilter('probe_insertion__session__id')

--- a/alyx/experiments/views.py
+++ b/alyx/experiments/views.py
@@ -168,13 +168,14 @@ class ProbeInsertionList(generics.ListCreateAPIView):
 
 class ProbeInsertionDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = ProbeInsertion.objects.all()
+    queryset = ProbeInsertionDetailSerializer.setup_eager_loading(queryset)
     serializer_class = ProbeInsertionDetailSerializer
     permission_classes = rest_permission_classes()
 
 
 class ChronicInsertionFilter(BaseFilterSet):
-    subject = CharFilter('subject__nickname')
-    lab = CharFilter('lab__name')
+    subject = CharFilter('session__subject__nickname')
+    lab = CharFilter('session__lab__name')
     model = CharFilter('model__name')
     probe = UUIDFilter('probe_insertion__id')
     session = UUIDFilter('probe_insertion__session__id')
@@ -445,6 +446,7 @@ class FOVList(generics.ListCreateAPIView):
     [===> FOV model reference](/admin/doc/models/experiments.fov)
     """
     queryset = FOV.objects.all()
+    queryset = FOVSerializer.setup_eager_loading(queryset)
     serializer_class = FOVSerializer
     permission_classes = rest_permission_classes()
     filterset_class = FOVFilter
@@ -485,6 +487,7 @@ class FOVLocationList(generics.ListCreateAPIView):
     [===> FOVLocation model reference](/admin/doc/models/experiments.fovlocation)
     """
     queryset = FOVLocation.objects.all()
+    queryset = FOVLocationListSerializer.setup_eager_loading(queryset)
     permission_classes = rest_permission_classes()
     filterset_class = FOVLocationFilter
 
@@ -499,6 +502,7 @@ class FOVLocationList(generics.ListCreateAPIView):
 
 class FOVLocationDetail(generics.RetrieveUpdateDestroyAPIView):
     queryset = FOVLocation.objects.all()
+    queryset = FOVLocationDetailSerializer.setup_eager_loading(queryset)
     serializer_class = FOVLocationDetailSerializer
     permission_classes = rest_permission_classes()
 
@@ -534,7 +538,7 @@ class ImagingStackList(generics.ListCreateAPIView):
     [===> ImagingStack model reference](/admin/doc/models/experiments.imagingstack)
     """
     queryset = ImagingStack.objects.all()
-    # serializer_class = ImagingStackListSerializer
+    queryset = ImagingStackDetailSerializer.setup_eager_loading(queryset)
     permission_classes = rest_permission_classes()
     filterset_class = ImagingStackFilter
 
@@ -550,5 +554,6 @@ class ImagingStackDetail(generics.RetrieveAPIView):
     [===> ImagingStack model reference](/admin/doc/models/experiments.imagingstack)
     """
     queryset = ImagingStack.objects.all()
+    queryset = ImagingStackDetailSerializer.setup_eager_loading(queryset)
     serializer_class = ImagingStackDetailSerializer
     permission_classes = rest_permission_classes()

--- a/alyx/jobs/admin.py
+++ b/alyx/jobs/admin.py
@@ -26,6 +26,8 @@ class TaskAdmin(BaseAdmin):
     def has_change_permission(self, request, obj=None):
         if request.user.is_superuser:
             return True
+        if request.user.is_public_user:
+            return False
         if obj:
             if obj.session:
                 # Check if session user or member of the same lab

--- a/alyx/jobs/tests.py
+++ b/alyx/jobs/tests.py
@@ -2,7 +2,6 @@ from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.urls import reverse
-from django.core.management import call_command
 from datetime import datetime, timedelta
 
 from actions.models import Session
@@ -15,10 +14,9 @@ from misc.models import Lab
 
 
 class APISubjectsTests(BaseTests):
+    fixtures = ['experiments.probemodel.json', 'experiments.brainregion.json']
 
     def setUp(self):
-        call_command('loaddata', 'experiments/fixtures/experiments.probemodel.json', verbosity=0)
-        call_command('loaddata', 'experiments/fixtures/experiments.brainregion.json', verbosity=0)
         self.superuser = get_user_model().objects.create_superuser('test', 'test', 'test')
         self.client.login(username='test', password='test')
         self.session = Session.objects.first()

--- a/alyx/jobs/tests_admin.py
+++ b/alyx/jobs/tests_admin.py
@@ -1,0 +1,80 @@
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+from django.test import Client
+from django.contrib.admin.sites import AdminSite
+from django.forms import fields
+# from django.contrib.auth.models import Group, Permission
+
+from misc.models import LabMember, Lab, LabMembership
+from subjects.models import Subject
+from actions.models import Session
+from data.models import DataRepositoryType, DataRepository
+from misc.management.commands.set_user_permissions import Command
+from jobs.admin import TaskAdmin
+from jobs.models import Task
+
+
+class TestJobsAdminViews(TestCase):
+    fixtures = ['data.datarepositorytype.json', 'misc.lab.json']
+
+    def setUp(self):
+        self.client = Client()
+        self.user = LabMember.objects.create_user(
+            username='foo', password='bar123', email='foo@example.com')
+        self.user.is_staff = self.user.is_active = True  # used by below Command instance
+        self.user.save()
+
+        self.superuser = LabMember.objects.create_superuser(
+            username='admin', password='admin', email='admin@example.com')
+        Command().handle()  # set user group permissions
+        self.client.login(username='foo', password='bar123')
+        repo_type = DataRepositoryType.objects.get(name='Fileserver')
+        self.repo = DataRepository.objects.create(name='test_repo', repository_type=repo_type)
+        self.task = Task.objects.create(
+            name='test_task', status=10, level=0, data_repository=self.repo)
+        self.lab = Lab.objects.get(name='cortexlab')
+        self.lab.repositories.add(self.repo)
+
+    def test_admin_add_form_view(self):
+        """Test the task add form view."""
+        response = self.client.get('/admin/jobs/task/add/', follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.client.login(username='admin', password='admin')
+        response = self.client.get('/admin/jobs/task/add/', follow=True)
+        self.assertEqual(response.status_code, 200)
+        ta = TaskAdmin(model=Task, admin_site=AdminSite())
+        self.assertCountEqual(['session', 'log', 'parents'], ta.readonly_fields)
+        request = MagicMock()
+        request.user = self.user
+        form = ta.get_form(request)
+        # All model fields should be present in the form except the following
+        expected = {'session', 'id', 'datetime', 'log'}
+        excluded = {x.name for x in Task._meta.fields} - set(form.base_fields.keys())
+        self.assertEqual(expected, excluded)
+        self.assertIsInstance(form.base_fields['status'], fields.ChoiceField)
+        # response = ta.add_view(request)  # in future we may want to test form submission
+
+    def test_has_change_permission(self):
+        """Test the has_change_permission method of the TaskAdmin class."""
+        ta = TaskAdmin(model=Task, admin_site=AdminSite())
+        request = MagicMock()
+        request.user = self.user
+
+        self.assertEqual(18, len(ta.get_fields(request)))
+        # Check if the user has permission to change a task
+        self.assertFalse(ta.has_change_permission(request))
+        self.assertFalse(ta.has_change_permission(request, obj=self.task))
+        # Check if the user has permission to change task when member of the same lab
+        membership = LabMembership.objects.create(lab=self.lab, user=self.user)
+        self.user.lab_id().contains(self.lab)
+        self.assertTrue(ta.has_change_permission(request, obj=self.task))
+        # Check if the user has permission to change task when user of the task session
+        membership.delete()
+        subject = Subject.objects.create(nickname='586', lab=self.lab)
+        session = Session.objects.create(
+            subject=subject, number=1, type='Experiment', task_protocol='foo')
+        session.users.add(self.user)
+        # Check superuser permissions
+        request.user = self.superuser
+        self.assertTrue(ta.has_change_permission(request))

--- a/alyx/misc/admin.py
+++ b/alyx/misc/admin.py
@@ -9,6 +9,7 @@ from django.contrib.contenttypes.admin import GenericTabularInline
 from django.contrib.postgres.fields import JSONField
 from django.utils.html import format_html, format_html_join
 from django.utils.safestring import mark_safe
+from rest_framework.authtoken.models import TokenProxy
 
 from misc.models import Note, Lab, LabMembership, LabLocation, CageType, \
     Enrichment, Food, Housing, HousingSubject
@@ -276,3 +277,4 @@ admin.site.register(Note, NoteAdmin)
 admin.site.register(CageType, CageTypeAdmin)
 admin.site.register(Enrichment, EnrichmentAdmin)
 admin.site.register(Food, FoodAdmin)
+admin.site.unregister(TokenProxy)

--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -1,11 +1,11 @@
 asgiref==3.8.1
 backports.zoneinfo==0.2.1
-boto3==1.35.82
-botocore==1.35.82
+boto3==1.35.94
+botocore==1.35.94
 certifi==2024.12.14
 cffi==1.17.1
-charset-normalizer==3.4.0
-click==8.1.7
+charset-normalizer==3.4.1
+click==8.1.8
 colorlog==6.9.0
 contourpy==1.1.1
 coreapi==2.3.3
@@ -41,7 +41,7 @@ idna==3.10
 importlib_metadata==8.5.0
 importlib_resources==6.4.5
 itypes==1.2.0
-Jinja2==3.1.4
+Jinja2==3.1.5
 jmespath==1.0.1
 kiwisolver==1.4.7
 llvmlite==0.41.1

--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -1,8 +1,8 @@
 asgiref==3.8.1
 backports.zoneinfo==0.2.1
-boto3==1.35.71
-botocore==1.35.71
-certifi==2024.8.30
+boto3==1.35.82
+botocore==1.35.82
+certifi==2024.12.14
 cffi==1.17.1
 charset-normalizer==3.4.0
 click==8.1.7
@@ -14,7 +14,7 @@ coverage==7.6.1
 coveralls==4.0.1
 cryptography==44.0.0
 cycler==0.12.1
-Django==4.2.16
+Django==4.2.17
 django-admin-list-filter-dropdown==1.0.3
 django-admin-rangefilter==0.13.2
 django-autocomplete-light==3.11.0
@@ -33,7 +33,7 @@ docopt==0.6.2
 docutils==0.20.1
 drfdocs==0.0.11
 flake8==7.1.1
-fonttools==4.55.0
+fonttools==4.55.3
 globus-cli==3.32.0
 globus-sdk==3.46.0
 iblutil==1.14.0
@@ -52,7 +52,7 @@ matplotlib==3.7.5
 mccabe==0.7.0
 numba==0.58.1
 numpy==1.24.4
-ONE-api==2.11.1
+ONE-api==2.11.2
 packaging==24.2
 pandas==2.0.3
 pillow==10.4.0
@@ -70,8 +70,8 @@ pytz==2024.2
 PyYAML==6.0.2
 requests==2.32.3
 s3transfer==0.10.4
-six==1.16.0
-sqlparse==0.5.2
+six==1.17.0
+sqlparse==0.5.3
 structlog==24.4.0
 tomli==2.2.1
 tqdm==4.67.1

--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -1,7 +1,7 @@
 asgiref==3.8.1
 backports.zoneinfo==0.2.1
-boto3==1.35.65
-botocore==1.35.65
+boto3==1.35.71
+botocore==1.35.71
 certifi==2024.8.30
 cffi==1.17.1
 charset-normalizer==3.4.0
@@ -12,7 +12,7 @@ coreapi==2.3.3
 coreschema==0.0.4
 coverage==7.6.1
 coveralls==4.0.1
-cryptography==43.0.3
+cryptography==44.0.0
 cycler==0.12.1
 Django==4.2.16
 django-admin-list-filter-dropdown==1.0.3
@@ -69,12 +69,12 @@ python-magic==0.4.27
 pytz==2024.2
 PyYAML==6.0.2
 requests==2.32.3
-s3transfer==0.10.3
+s3transfer==0.10.4
 six==1.16.0
 sqlparse==0.5.2
 structlog==24.4.0
-tomli==2.1.0
-tqdm==4.67.0
+tomli==2.2.1
+tqdm==4.67.1
 typing_extensions==4.12.2
 tzdata==2024.2
 uritemplate==4.1.1


### PR DESCRIPTION
## Release notes
### rest
- Optimizations for imaging and insertion serializers
- Added field of view location read REST action
- Bugfix for creating session without users field
### fixtures
- _sp_video.times dataset type
- taskData.raw dataset type can now have any namespace (for personal projects)
- Water 1% Citric Acid water type fixture (used in IBL and cortexlab)
### system
- Remove user login tokens page from admin interface
- Fix user permissions for task page
- Admin interface tests for jobs app

## Release steps below

After pulling the changes from github...

### 1) Activate environment, cd to the alyx folder and install requirements
git stash
git pull
git stash pop

### 2) Activate environment - install requirements (if new packages)
pip install -r requirements_frozen.txt

### 3) Update the database if any scheme changes - we expect no migrations
cd alyx
./manage.py makemigrations
./manage.py migrate

### 4) If new fixtures load in the database:
../scripts/load-init-fixtures.sh

### 5) if new tables change the postgres permissions
./manage.py set_db_permissions
./manage.py set_user_permissions

### 6) If updates to django version
./manage.py collectstatic --no-input

### 7) Restart the Apache server
sudo service apache2 restart
