### PR TITLE
Skip 443 virtual host if ssl module not enabled

### DIFF
--- a/deploy/docker/000-default-conf-alyx
+++ b/deploy/docker/000-default-conf-alyx
@@ -3,40 +3,42 @@
     Redirect permanent / https://${APACHE_SERVER_NAME}/
 </VirtualHost>
 
-<VirtualHost *:443>
-    ServerName ${APACHE_SERVER_NAME}
-    ServerAdmin webmaster@internationalbrainlab.org
-    DocumentRoot /var/www/alyx
-
-    <Directory /var/www/alyx/alyx/alyx>
-        <Files wsgi.py>
+<IfModule mod_ssl.c>
+    <VirtualHost *:443>
+        ServerName ${APACHE_SERVER_NAME}
+        ServerAdmin webmaster@internationalbrainlab.org
+        DocumentRoot /var/www/alyx
+    
+        <Directory /var/www/alyx/alyx/alyx>
+            <Files wsgi.py>
+                Require all granted
+            </Files>
+        </Directory>
+    
+        Alias /static/ /var/www/alyx/alyx/static/
+        Alias /media/ /var/www/alyx/alyx/media/
+    
+        <Directory /var/www/alyx/alyx/static>
             Require all granted
-        </Files>
-    </Directory>
-
-    Alias /static/ /var/www/alyx/alyx/static/
-    Alias /media/ /var/www/alyx/alyx/media/
-
-    <Directory /var/www/alyx/alyx/static>
-        Require all granted
-    </Directory>
-
-    <Directory /var/www/alyx/alyx/media>
-        Require all granted
-    </Directory>
-
-    ErrorLog ${APACHE_LOG_DIR}/error_alyx.log
-    CustomLog ${APACHE_LOG_DIR}/access_alyx.log combined
-
-    WSGIApplicationGroup %{GLOBAL}
-    WSGIDaemonProcess alyx python-path=/var/www/alyx/alyx python-home=/var/www/alyx/.venv socket-user=#33 listen-backlog=50
-    WSGIProcessGroup alyx
-    WSGIScriptAlias / /var/www/alyx/alyx/alyx/wsgi.py
-    WSGIPassAuthorization On
-
-    SSLProtocol             all -SSLv2 -SSLv3
-    SSLCipherSuite          ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS
-    SSLHonorCipherOrder     on
-    SSLCompression          off
-    SSLOptions +StrictRequire
-</VirtualHost>
+        </Directory>
+    
+        <Directory /var/www/alyx/alyx/media>
+            Require all granted
+        </Directory>
+    
+        ErrorLog ${APACHE_LOG_DIR}/error_alyx.log
+        CustomLog ${APACHE_LOG_DIR}/access_alyx.log combined
+    
+        WSGIApplicationGroup %{GLOBAL}
+        WSGIDaemonProcess alyx python-path=/var/www/alyx/alyx python-home=/var/www/alyx/.venv socket-user=#33 listen-backlog=50
+        WSGIProcessGroup alyx
+        WSGIScriptAlias / /var/www/alyx/alyx/alyx/wsgi.py
+        WSGIPassAuthorization On
+    
+        SSLProtocol             all -SSLv2 -SSLv3
+        SSLCipherSuite          ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS
+        SSLHonorCipherOrder     on
+        SSLCompression          off
+        SSLOptions +StrictRequire
+    </VirtualHost>
+</IfModule>


### PR DESCRIPTION
We may want to remove line [69 of Dockerfile_base](https://github.com/cortex-lab/alyx/blob/9477347f164aaccb42d8e47aeb9e020f50c7e9a4/deploy/docker/Dockerfile_base#L69C1-L69C16) where the SSL module is enabled, although this could also be done within a different workflow contingent on the absence of certificates.