### PR TITLE
initial commit - FiberInsertions and other related tables - draft

### DIFF
--- a/alyx/actions/admin.py
+++ b/alyx/actions/admin.py
@@ -17,7 +17,8 @@ from rangefilter.filters import DateRangeFilter
 from alyx.base import (BaseAdmin, DefaultListFilter, BaseInlineAdmin, get_admin_url)
 from .models import (OtherAction, ProcedureType, Session, EphysSession, Surgery, VirusInjection,
                      WaterAdministration, WaterRestriction, Weighing, WaterType,
-                     Notification, NotificationRule, Cull, CullReason, CullMethod, ImagingSession
+                     Notification, NotificationRule, Cull, CullReason, CullMethod, ImagingSession, 
+                     FiberInsertion
                      )
 from data.models import Dataset, FileRecord
 from misc.admin import NoteInline
@@ -682,6 +683,12 @@ class ProbeInsertionInline(TabularInline):
     fields = ('name', 'model')
     extra = 0
 
+class FiberInsertionInline(TabularInline):
+    fk_name = "session"
+    show_change_link = True
+    model = FiberInsertion
+    fields = ('name', 'fiber_model')
+    extra = 0
 
 class FOVInline(TabularInline):
     fk_name = 'session'
@@ -697,6 +704,14 @@ class EphysSessionAdmin(SessionAdmin):
     def get_queryset(self, request):
         qs = super(EphysSessionAdmin, self).get_queryset(request)
         return qs.filter(procedures__name__icontains='ephys')
+
+
+class PhotometrySessionAdmin(SessionAdmin):
+    inlines = [FiberInsertionInline, TasksAdminInline, WaterAdminInline, DatasetInline, NoteInline]
+
+    def get_queryset(self, request):
+        qs = super(PhotometrySessionAdmin, self).get_queryset(request)
+        return qs.filter(procedures__name__icontains='Fiber photometry')
 
 
 class ImagingSessionAdmin(SessionAdmin):

--- a/alyx/actions/admin.py
+++ b/alyx/actions/admin.py
@@ -17,15 +17,14 @@ from rangefilter.filters import DateRangeFilter
 from alyx.base import (BaseAdmin, DefaultListFilter, BaseInlineAdmin, get_admin_url)
 from .models import (OtherAction, ProcedureType, Session, EphysSession, Surgery, VirusInjection,
                      WaterAdministration, WaterRestriction, Weighing, WaterType,
-                     Notification, NotificationRule, Cull, CullReason, CullMethod, ImagingSession, 
-                     FiberInsertion
+                     Notification, NotificationRule, Cull, CullReason, CullMethod, ImagingSession,
                      )
 from data.models import Dataset, FileRecord
 from misc.admin import NoteInline
 from misc.models import Note
 from subjects.models import Subject
 from .water_control import WaterControl
-from experiments.models import ProbeInsertion, FOV
+from experiments.models import ProbeInsertion, FOV, FiberInsertion
 from jobs.models import Task
 
 logger = logging.getLogger(__name__)

--- a/alyx/actions/models.py
+++ b/alyx/actions/models.py
@@ -316,6 +316,15 @@ class ImagingSession(Session):
     class Meta:
         proxy = True
 
+class PhotometrySession(Session):
+    """
+    This proxy class allows to register as a different admin page.
+    The database is left untouched.
+    New methods are fine but not new fields.
+    For what defines an photometry session see actions.admin.PhotometrySessionAdmin.get_queryset.
+    """
+    class Meta:
+        proxy = True
 
 class WaterRestriction(BaseAction):
     """

--- a/alyx/experiments/models.py
+++ b/alyx/experiments/models.py
@@ -422,7 +422,7 @@ class FiberTipLocation(BaseModel):
     y = models.FloatField(blank=True, null=True, help_text=Y_HELP_TEXT, verbose_name='y-ap (um)')
     z = models.FloatField(blank=True, null=True, help_text=Z_HELP_TEXT, verbose_name='z-dv (um)')
     brain_region = models.ForeignKey(BrainRegion, default=0, null=True, blank=True,
-                                     on_delete=models.SET_NULL, related_name='channels')
+                                     on_delete=models.SET_NULL, related_name='fiber_tip_location')
     fiber_trajectory_estimate = models.ForeignKey(FiberTrajectoryEstimate, null=True, blank=True,
                                             on_delete=models.CASCADE, related_name='fiber_tip_location')
 

--- a/alyx/experiments/models.py
+++ b/alyx/experiments/models.py
@@ -240,7 +240,7 @@ class FiberModel(BaseModel):  # maybe this shouldn't be based on a ProbeModel bu
     diameter = models.FloatField(null=False, help_text="fiber diameter in um, e.g. 200")
     length = models.FloatField(null=False, help_text="fiber length in mm, e.g. 6")
     tip_type = models.CharField(default="flat", null=False, help_text="fiber tip type, e.g. flat, tapered etc.")
-    tip_parameter = models.FloatFiled(null=True, help_text="fiber shape parameter, e.g. tip angle, taper length")
+    tip_parameter = models.FloatField(null=True, help_text="fiber shape parameter, e.g. tip angle, taper length")
     description = models.CharField(
         max_length=255,
         null=True,

--- a/alyx/experiments/models.py
+++ b/alyx/experiments/models.py
@@ -385,7 +385,7 @@ class FiberTrajectoryEstimate(models.Model):
                                     name='unique_fiber_trajectory_per_chronic_provenance'),
             models.UniqueConstraint(fields=['provenance', 'fiber_insertion'],
                                     condition=models.Q(fiber_insertion__isnull=False),
-                                    name='unique_trajectory_per_provenance'),
+                                    name='unique_fiber_trajectory_per_provenance'),
         ]
 
     def __str__(self):

--- a/alyx/experiments/models.py
+++ b/alyx/experiments/models.py
@@ -382,7 +382,7 @@ class FiberTrajectoryEstimate(models.Model):
         constraints = [
             models.UniqueConstraint(fields=['provenance', 'chronic_fiber_insertion'],
                                     condition=models.Q(fiber_insertion__isnull=True),
-                                    name='unique_trajectory_per_chronic_provenance'),
+                                    name='unique_fiber_trajectory_per_chronic_provenance'),
             models.UniqueConstraint(fields=['provenance', 'fiber_insertion'],
                                     condition=models.Q(fiber_insertion__isnull=False),
                                     name='unique_trajectory_per_provenance'),

--- a/alyx/experiments/models.py
+++ b/alyx/experiments/models.py
@@ -380,7 +380,7 @@ class FiberTrajectoryEstimate(models.Model):
 
     class Meta:
         constraints = [
-            models.UniqueConstraint(fields=['provenance', ''],
+            models.UniqueConstraint(fields=['provenance', 'chronic_fiber_insertion'],
                                     condition=models.Q(fiber_insertion__isnull=True),
                                     name='unique_trajectory_per_chronic_provenance'),
             models.UniqueConstraint(fields=['provenance', 'fiber_insertion'],
@@ -390,12 +390,9 @@ class FiberTrajectoryEstimate(models.Model):
 
     def __str__(self):
         if self.fiber_insertion:
-            return "%s  %s/%s" % \
-                   (self.get_provenance_display(), str(self.session), self.fiber_insertion.name)
+            return f"{self.get_provenance_display()}  {self.session}/{self.fiber_insertion.name}"
         elif self.chronic_fiber_insertion:
-            return "%s  %s/%s" % \
-                   (self.get_provenance_display(), self.chronic_fiber_insertion.subject.nickname,
-                    self.chronic_fiber_insertion.name)
+            return f"{self.get_provenance_display()}  {self.chronic_fiber_insertion.subject.nickname}/{self.chronic_fiber_insertion.name}"
         else:
             return super().__str__()
 


### PR DESCRIPTION
Proposed changes for representing photometry / fiber based experiments in alyx, including
- `FiberModel` -> modeled after `ProbeModel`
- `FiberInsertion` -> modeled after `ProbeInsertion`
- `ChronicFiberInsertion` -> modeled after `ChronicInsertion`
- `FiberTrajectoryEstimate` -> modeled after `TrajectoryEstimate`
- `FiberTipLocation` -> modeled after `Channel`

main differences:
- Fibers don't have identifiable identities such as probes
- Fibers have a set of unique parameters such as diameter, NA, tip shape etc
- FiberInsertions are always chronic, but the `FiberInsertion` / `FiberChronicInsertion` logic is kept for consistency to ephys probes
- FiberTrajectories are not ephys aligned
-  A fiber has a single "channel" which is modeled by a `FiberTipLocation`

Not present yes:
Serializers / Views