### PR TITLE
Hotfixglobus

### DIFF
--- a/alyx/data/management/commands/transfers_integration.py
+++ b/alyx/data/management/commands/transfers_integration.py
@@ -9,10 +9,8 @@ from django.test import Client
 from django.core.management import BaseCommand
 from django.db.models import Q
 
-import os
 import numpy as np
 from pathlib import Path
-import json
 import globus_sdk as globus
 import time
 

--- a/alyx/data/management/commands/transfers_integration.py
+++ b/alyx/data/management/commands/transfers_integration.py
@@ -17,64 +17,16 @@ import globus_sdk as globus
 import time
 
 import traceback
-from one.remote.globus import GLOBUS_TRANSFER_SCOPE
+from one.remote.globus import Globus, as_globus_path, get_local_endpoint_paths
+import one.params
 
-from alyx.settings_lab import GLOBUS_CLIENT_ID
 # TODO some way to get the hostname automatically
 SERVER_NAME = 'localhost:8000'
 
 
-def globus_login(globus_client_id):
-    # This assumes globus stuff has been setup using ibllib.io.globus. Ideally need to make globus
-    # functions in data.transfers flexible so it can deal with either alyx or ibllib way!
-    token_path = Path.home().joinpath('.globus', '.admin')
-    with open(token_path, 'r') as f:
-        token = json.load(f)
-    client = globus.NativeAppAuthClient(globus_client_id)
-    client.oauth2_start_flow(refresh_tokens=True, requested_scopes=GLOBUS_TRANSFER_SCOPE)
-    authorizer = globus.RefreshTokenAuthorizer(token['refresh_token'], client)
-
-    return globus.TransferClient(authorizer=authorizer)
-
-
-def get_local_endpoint():
-    """
-    Get the local endpoint id of the computer
-    :return:
-    """
-    id_path = Path.home().joinpath(".globusonline", "lta")
-    with open(id_path.joinpath("client-id.txt"), 'r') as fid:
-        globus_id = fid.read()
-    return globus_id.strip()
-
-
-def get_local_globus_path():
-    config_path = Path.home().joinpath(".globusonline", "lta")
-    message = 'Please make a config-paths file in ./globus/lta that contains the ' \
-              'folder on your local endpoint accessible by globus e.g echo "/mnt/s0/Data" > ' \
-              '~/.globusonline/lta/config-paths'
-    assert config_path.joinpath("config-paths").exists(), message
-    with open(config_path.joinpath("config-paths"), 'r') as fid:
-        globus_path = fid.read()
-
-    return globus_path.strip().split(',')[0]
-
-
-def get_local_path(local_globus_path):
-    if os.environ.get('WSL_DISTRO_NAME', None):
-        local_path = str(Path('/mnt/c/').joinpath(*local_globus_path.split('/')[2:])) + '/'
-    else:
-        local_path = local_globus_path
-    return local_path
-
-
 def client_login(client):
-    one_path = Path.home().joinpath('.one_params')
-    with open(one_path, 'r') as f:
-        one = json.load(f)
-
-    client.login(username=one['ALYX_LOGIN'], password=one['ALYX_PWD'])
-
+    pars = one.params.get(silent=True)
+    client.login(username=pars.ALYX_LOGIN, password=pars.ALYX_PWD)
     return client
 
 
@@ -105,12 +57,12 @@ class TestTransfers(object):
     def setUp(self) -> None:
 
         # Make sure we can log in
-        self.gtc = globus_login(GLOBUS_CLIENT_ID)
+        self.globus = Globus('alyx', headless=True)
+        self.gtc = self.globus.client
         assert self.gtc
 
         # Check that the local endpoint is connected
-        self.local_endpoint_id = get_local_endpoint()
-        endpoint_info = self.gtc.get_endpoint(self.local_endpoint_id)
+        endpoint_info = self.gtc.get_endpoint(self.globus.endpoints['local']['id'])
         assert endpoint_info['gcp_connected']
 
         # Check that the flatiron endpoint is connected
@@ -121,8 +73,8 @@ class TestTransfers(object):
         assert endpoint_info['gcp_connected'] is not False
 
         # Make sure we have the correct accessible local globus path
-        local_globus_path = get_local_globus_path()
-        assert self.gtc.operation_ls(self.local_endpoint_id, path=local_globus_path)
+        local_globus_path = get_local_endpoint_paths()[0]
+        assert self.gtc.operation_ls(self.globus.endpoints['local']['id'], path=local_globus_path)
 
         # Connect to client and check we can log in properly
         client = Client()
@@ -164,7 +116,7 @@ class TestTransfers(object):
         self.local_data_repo, _ = DataRepository.\
             objects.get_or_create(name=name, repository_type=repo_type,
                                   globus_path=self.local_globus_path,
-                                  globus_endpoint_id=self.local_endpoint_id,
+                                  globus_endpoint_id=self.globus.endpoints['local']['id'],
                                   globus_is_personal=globus_is_personal)
 
         # 3. Make an aws file server
@@ -204,7 +156,7 @@ class TestTransfers(object):
         """
         TEST TRANSFER OF DATA WITH NO REVISIONS
         """
-        local_path = get_local_path(self.local_globus_path)
+        local_path = as_globus_path(self.local_globus_path)
         collection = 'alf/probe00'
         revision = None
 
@@ -276,7 +228,7 @@ class TestTransfers(object):
 
         # Run in dry mode and check you get the correct
         dm = globus_delete_local_datasets(dsets_to_del, dry=True, gc=self.gtc)
-        assert dm['endpoint'] == self.local_endpoint_id
+        assert dm['endpoint'] == self.globus.endpoints['local']['id']
         assert dm['DATA'][0]['path'] == exp_files[0]
         # Make sure dry mode hasn't actually deleted anything
         self.assert_delete_datasets(dsets_to_del, before_del=True)
@@ -287,7 +239,7 @@ class TestTransfers(object):
 
         time.sleep(5)
         # Make sure the dataset has been deleted on local endpoint
-        ls_local = self.gtc.operation_ls(self.local_endpoint_id,
+        ls_local = self.gtc.operation_ls(self.globus.endpoints['local']['id'],
                                          path=str(Path(exp_files[0]).parent))
         ls_files = [ls['name'] for ls in ls_local['DATA']]
         assert Path(exp_files[0]).name not in ls_files
@@ -330,7 +282,7 @@ class TestTransfers(object):
         self.assert_delete_datasets(dsets_to_del, local_only=True)
 
         time.sleep(5)
-        ls_local = self.gtc.operation_ls(self.local_endpoint_id,
+        ls_local = self.gtc.operation_ls(self.globus.endpoints['local']['id'],
                                          path=str(Path(exp_files[0]).parent))
         # have spikes.times left
         assert len(ls_local['DATA']) == 1
@@ -510,7 +462,7 @@ class TestTransfers(object):
 
         # Delete the session folders on flatiron and on local computer
         # Delete from local computer
-        local_delete = globus.DeleteData(self.gtc, self.local_endpoint_id, recursive=True)
+        local_delete = globus.DeleteData(self.gtc, self.globus.endpoints['local']['id'], recursive=True)
         local_delete.add_item(self.local_globus_path + self.session_path)
         self.gtc.submit_delete(local_delete)
 

--- a/alyx/data/management/commands/transfers_integration.py
+++ b/alyx/data/management/commands/transfers_integration.py
@@ -17,6 +17,7 @@ import globus_sdk as globus
 import time
 
 import traceback
+from one.remote.globus import GLOBUS_TRANSFER_SCOPE
 
 from alyx.settings_lab import GLOBUS_CLIENT_ID
 # TODO some way to get the hostname automatically
@@ -30,7 +31,7 @@ def globus_login(globus_client_id):
     with open(token_path, 'r') as f:
         token = json.load(f)
     client = globus.NativeAppAuthClient(globus_client_id)
-    client.oauth2_start_flow(refresh_tokens=True)
+    client.oauth2_start_flow(refresh_tokens=True, requested_scopes=GLOBUS_TRANSFER_SCOPE)
     authorizer = globus.RefreshTokenAuthorizer(token['refresh_token'], client)
 
     return globus.TransferClient(authorizer=authorizer)

--- a/alyx/data/tests.py
+++ b/alyx/data/tests.py
@@ -195,10 +195,10 @@ class TestManagementFiles(TestCase):
         )
         self.assertEqual(['subject/2020-01-01/001/foo.bar.baz'], fr)
 
-    def _new_delete_client(self, _, gid, **kwargs):
+    def _new_delete_client(self, endpoint, **kwargs):
         """Upon calling DeleteData, return dict-like mock"""
-        d = {'DATA': kwargs, 'endpoint': str(gid)}
-        self.delete_clients.append(mock.MagicMock(name=f'delete_obj_{gid}'))
+        d = {'DATA': kwargs, 'endpoint': str(endpoint)}
+        self.delete_clients.append(mock.MagicMock(name=f'delete_obj_{endpoint}'))
         self.delete_clients[-1].__getitem__.side_effect = d.__getitem__
         return self.delete_clients[-1]
 

--- a/alyx/data/transfers.py
+++ b/alyx/data/transfers.py
@@ -804,7 +804,7 @@ def globus_delete_local_datasets(datasets, dry=True, gc=None, label=None):
             fr2delete.append(frloc.id)
             file2del = _filename_from_file_record(frloc)
             del_client = delete_clients[(gid := frloc.data_repository.globus_endpoint_id)]
-            assert del_client['endpoint'] == gid  # both are UUIDs now
+            assert str(del_client['endpoint']) == str(gid)  # both are UUIDs now
             del_client.add_item(file2del)
             logger.info('DELETE: ' + _filename_from_file_record(frloc))
     # launch the deletion jobs and remove records from the database

--- a/alyx/data/transfers.py
+++ b/alyx/data/transfers.py
@@ -133,7 +133,10 @@ def start_globus_transfer(source_file_id, destination_file_id, dry_run=False):
     )
     tc = globus_transfer_client()
     tdata = globus_sdk.TransferData(
-        tc, source_id, destination_id, verify_checksum=True, sync_level='checksum',
+        source_endpoint=source_id,
+        destination_endpoint=destination_id,
+        verify_checksum=True,
+        sync_level='checksum',
         label=label[0: min(len(label), 128)],
     )
     tdata.add_item(source_path, destination_path)
@@ -658,7 +661,6 @@ def _globus_transfer_filerecords(dfs, dry=True, gc=None):
             label = sec_repos[isec].name + ' to ' + pri_repos[ipri].name
             if not dry:
                 tm[ipri][isec] = globus_sdk.TransferData(
-                    gc,
                     source_endpoint=sec_repos[isec].globus_endpoint_id,
                     destination_endpoint=pri_repos[ipri].globus_endpoint_id,
                     verify_checksum=True,

--- a/alyx/data/transfers.py
+++ b/alyx/data/transfers.py
@@ -6,15 +6,16 @@ import re
 import time
 from pathlib import Path, PurePosixPath, PurePath
 
+from django.conf import settings
 from django.db.models import Case, When, Count, Q, F
 import globus_sdk
 import numpy as np
 from one.alf.path import add_uuid_string, folder_parts
 from one.registration import get_dataset_type
 from one.alf.spec import QC, regex, COLLECTION_SPEC
-from one.remote.globus import GLOBUS_TRANSFER_SCOPE
+import one.params
+from one.remote.globus import Globus, get_local_endpoint_id, get_local_endpoint_paths, DEFAULT_PAR
 
-from alyx import settings
 from data.models import FileRecord, Dataset, DatasetType, DataFormat, DataRepository
 from rest_framework.response import Response
 from actions.models import Session
@@ -22,61 +23,22 @@ from subjects.models import Subject
 
 logger = logging.getLogger(__name__)
 
-# Login
-# ------------------------------------------------------------------------------------------------
-
-
-def get_config_path(path=''):
-    path = op.expanduser(op.join('~/.alyx', path))
-    os.makedirs(op.dirname(path), exist_ok=True)
-    return path
-
-
-def create_globus_client():
-    # FIXME use ONE Globus client instead
-    client = globus_sdk.NativeAppAuthClient(settings.GLOBUS_CLIENT_ID)
-    client.oauth2_start_flow(refresh_tokens=True, requested_scopes=GLOBUS_TRANSFER_SCOPE)
-    return client
-
-
-def create_globus_token():
-    client = create_globus_client()
-    print('Please go to this URL and login: {0}'
-          .format(client.oauth2_get_authorize_url()))
-    get_input = getattr(__builtins__, 'raw_input', input)
-    auth_code = get_input('Please enter the code here: ').strip()
-    token_response = client.oauth2_exchange_code_for_tokens(auth_code)
-    globus_transfer_data = token_response.by_resource_server['transfer.api.globus.org']
-
-    data = dict(transfer_rt=globus_transfer_data['refresh_token'],
-                transfer_at=globus_transfer_data['access_token'],
-                expires_at_s=globus_transfer_data['expires_at_seconds'],
-                )
-    path = get_config_path('globus-token.json')
-    with open(path, 'w') as f:
-        json.dump(data, f, indent=2, sort_keys=True)
-
 
 # Data transfer
 # ------------------------------------------------------------------------------------------------
 
-def get_globus_transfer_rt():
-    path = get_config_path('globus-token.json')
-    if not op.exists(path):
-        return
-    with open(path, 'r') as f:
-        return json.load(f).get('transfer_rt', None)
-
 
 def globus_transfer_client():
-    transfer_rt = get_globus_transfer_rt()
-    if not transfer_rt:
-        create_globus_token()
-        transfer_rt = get_globus_transfer_rt()
-    client = create_globus_client()
-    authorizer = globus_sdk.RefreshTokenAuthorizer(transfer_rt, client)
-    tc = globus_sdk.TransferClient(authorizer=authorizer)
-    return tc
+    # If not set up via ONE, copy the old Globus token information to the ONE params file
+    config_new = Path.home().joinpath('.one', '.remote')
+    if not config_new.exists():
+        # Create the config file but ask user to log in
+        data = {'globus': {'alyx': DEFAULT_PAR}}
+        data['globus']['alyx']['GLOBUS_CLIENT_ID'] = settings.GLOBUS_CLIENT_ID
+        with open(config_new, 'w') as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+    globus = Globus('alyx', headless=True)
+    return globus.client
 
 
 def _escape_label(label):

--- a/alyx/data/transfers.py
+++ b/alyx/data/transfers.py
@@ -751,7 +751,7 @@ def globus_delete_local_datasets(datasets, dry=True, gc=None, label=None):
     # create a globus delete_client for each globus endpoint
     gtc = gc or globus_transfer_client()
     # Map of Globus endpoint UUID -> DeleteData client
-    delete_clients = {ge: globus_sdk.DeleteData(gtc, ge, label=label) for ge in globus_endpoints}
+    delete_clients = {ge: globus_sdk.DeleteData(endpoint=ge, label=label) for ge in globus_endpoints}
 
     def _ls_globus(file_record, add_uuid=False):
         N_RETRIES = 3
@@ -802,7 +802,7 @@ def globus_delete_local_datasets(datasets, dry=True, gc=None, label=None):
             fr2delete.append(frloc.id)
             file2del = _filename_from_file_record(frloc)
             del_client = delete_clients[(gid := frloc.data_repository.globus_endpoint_id)]
-            assert del_client['endpoint'] == str(gid)
+            assert del_client['endpoint'] == gid  # both are UUIDs now
             del_client.add_item(file2del)
             logger.info('DELETE: ' + _filename_from_file_record(frloc))
     # launch the deletion jobs and remove records from the database
@@ -865,7 +865,7 @@ def globus_delete_file_records(file_records, dry=True, gc=None, label=None):
     if not dry:
         # delete_clients = []
         for ge in globus_endpoints:
-            delete_clients.append(globus_sdk.DeleteData(gtc, ge, label=label))
+            delete_clients.append(globus_sdk.DeleteData(endpoint=ge, label=label))
     # appends each file for deletion
     for i, ge in enumerate(globus_endpoints):
         current_path = None

--- a/alyx/data/transfers.py
+++ b/alyx/data/transfers.py
@@ -12,6 +12,7 @@ import numpy as np
 from one.alf.path import add_uuid_string, folder_parts
 from one.registration import get_dataset_type
 from one.alf.spec import QC, regex, COLLECTION_SPEC
+from one.remote.globus import GLOBUS_TRANSFER_SCOPE
 
 from alyx import settings
 from data.models import FileRecord, Dataset, DatasetType, DataFormat, DataRepository
@@ -34,7 +35,7 @@ def get_config_path(path=''):
 def create_globus_client():
     # FIXME use ONE Globus client instead
     client = globus_sdk.NativeAppAuthClient(settings.GLOBUS_CLIENT_ID)
-    client.oauth2_start_flow(refresh_tokens=True)
+    client.oauth2_start_flow(refresh_tokens=True, requested_scopes=GLOBUS_TRANSFER_SCOPE)
     return client
 
 

--- a/alyx/data/transfers.py
+++ b/alyx/data/transfers.py
@@ -13,8 +13,7 @@ import numpy as np
 from one.alf.path import add_uuid_string, folder_parts
 from one.registration import get_dataset_type
 from one.alf.spec import QC, regex, COLLECTION_SPEC
-import one.params
-from one.remote.globus import Globus, get_local_endpoint_id, get_local_endpoint_paths, DEFAULT_PAR
+from one.remote.globus import Globus, DEFAULT_PAR
 
 from data.models import FileRecord, Dataset, DatasetType, DataFormat, DataRepository
 from rest_framework.response import Response

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,8 +20,8 @@ dotenv
 drfdocs
 flake8
 fonttools>=4.61.0
-globus-cli
-globus-sdk
+globus-cli>=3.41.0
+globus-sdk>=4.3.0
 gunicorn
 ipython
 markdown


### PR DESCRIPTION
The latest Globus has changed authentication workflows (the client ID of our app has disappeared), and the syntax of the transfer and delete objects.

I have refactored those in the transfers.py file, and set the minimum versions of both the globus-sdk and globus-cli to the current versions.

The current maintenance transfer workloads are supposed to be run from mbox2 from now on.