### PR TITLE
Small fixes: docs link, docker env file, weight help strings, uv.lock ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ alyx/.idea/
 alyx.log
 
 alyx/data/management/commands/create_public_links.py
+uv.lock

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Database for experimental neuroscience laboratories
 
 ## Installation
 
-[The getting started](https://alyx.readthedocs.io/en/latest/gettingstarted.html) section of the documentation details the steps for 
+[The getting started](https://alyx.readthedocs.io/en/latest/gettingstarted.html) section of the documentation details the steps for
 -   installing the Python/Django environment
 -   running the app with a development server
 -   registering local data
@@ -54,4 +54,3 @@ From the root of the repository.
 ````shell
 sphinx-autobuild -b html ./docs ./docs/_build/ --port 8700
 ````
-https://www.scan.co.uk/products/3xs-evolve-studio-pro-intel-core-ultra-9-285k-64gb-ddr5-16gb-nvidia-rtx-5070-ti-super-1tb-ssd-2tb-ss

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Database for experimental neuroscience laboratories
 
-[Documentation](https://alyx.readthedocs.io)
+[Documentation](https://cortex-lab.github.io/alyx/index.html)
 
 [Alyx Experimenter Guide](https://docs.google.com/document/d/1cx3XLZiZRh3lUzhhR_p65BggEqTKpXHUDkUDagvf9Kc/edit?usp=sharing)
 

--- a/alyx/misc/admin.py
+++ b/alyx/misc/admin.py
@@ -148,6 +148,7 @@ class NoteInline(GenericTabularInline):
     fields = ('user', 'date_time', 'text', 'image')
     image_fields = ('image',)
     ordering = ('-date_time',)
+    show_change_link = True
 
     formfield_overrides = {
         models.TextField: {'widget': forms.Textarea(

--- a/alyx/misc/models.py
+++ b/alyx/misc/models.py
@@ -87,13 +87,18 @@ class Lab(BaseModel):
 
     reference_weight_pct = models.FloatField(
         default=0.,
-        help_text="The minimum mouse weight is a linear combination of "
-        "the reference weight and the zscore weight.")
+        help_text="Fraction (0–1) of the mouse's own reference weight (weight at water-restriction "
+        "start) used as the minimum acceptable weight threshold. E.g. 0.85 requires the mouse to "
+        "stay above 85 % of its reference weight.")
 
     zscore_weight_pct = models.FloatField(
         default=0.,
-        help_text="The minimum mouse weight is a linear combination of "
-        "the reference weight and the zscore weight.")
+        help_text="Fraction (0–1) of the age/sex population-normalised (z-score) weight used as "
+        "the minimum acceptable weight threshold. The z-score weight projects the mouse's weight "
+        "z-score at water-restriction start onto the population growth curve at the current age. "
+        "E.g. 0.85 requires the mouse to stay above 85 % of its expected age/sex weight. When "
+        "both zscore_weight_pct and reference_weight_pct are non-zero, the expected weight is "
+        "their weighted average.")
     # those are all the default fields for populating Housing tables
     cage_type = models.ForeignKey('CageType', on_delete=models.SET_NULL, null=True, blank=True)
     enrichment = models.ForeignKey('Enrichment', on_delete=models.SET_NULL, null=True, blank=True)

--- a/deploy/docker-compose-postgres-gunicorn.yaml
+++ b/deploy/docker-compose-postgres-gunicorn.yaml
@@ -4,7 +4,7 @@ services:
     container_name: alyx_apache
     ports:
       - "8000:8000"
-    env_file: ../alyx/alyx/.env
+    env_file: ../alyx/alyx/.env_prod
     command: >
       bash -c "python /var/www/alyx/alyx/manage.py collectstatic --noinput &&
                gunicorn --workers 2 -b 0.0.0.0:8000 alyx.gunicorn_wsgi:application"
@@ -19,7 +19,7 @@ services:
   postgres:
     image: postgres:17
     container_name: alyx_postgres
-    env_file: ../alyx/alyx/.env
+    env_file: ../alyx/alyx/.env_prod
     volumes:
       - alyx_postgres:/var/lib/postgresql/data
     expose:

--- a/deploy/docker-compose-postgres-gunicorn.yaml
+++ b/deploy/docker-compose-postgres-gunicorn.yaml
@@ -4,7 +4,7 @@ services:
     container_name: alyx_apache
     ports:
       - "8000:8000"
-    env_file: ../alyx/alyx/.env_prod
+    env_file: ../alyx/alyx/.env
     command: >
       bash -c "python /var/www/alyx/alyx/manage.py collectstatic --noinput &&
                gunicorn --workers 2 -b 0.0.0.0:8000 alyx.gunicorn_wsgi:application"
@@ -19,7 +19,7 @@ services:
   postgres:
     image: postgres:17
     container_name: alyx_postgres
-    env_file: ../alyx/alyx/.env_prod
+    env_file: ../alyx/alyx/.env
     volumes:
       - alyx_postgres:/var/lib/postgresql/data
     expose:

--- a/deploy/docker-compose-postgres.yaml
+++ b/deploy/docker-compose-postgres.yaml
@@ -2,7 +2,7 @@ services:
   postgres:
     image: postgres:17
     container_name: alyx_postgres
-    env_file: ../alyx/alyx/.env_prod
+    env_file: ../alyx/alyx/.env
     volumes:
       - alyx_postgres:/var/lib/postgresql/data
     ports:


### PR DESCRIPTION
## Summary
- Update docs URL in README to cortex-lab GitHub Pages
- Fix docker-compose env file reference (`.env` → `.env_prod`)
- Improve help strings for `Lab.reference_weight_pct` and `Lab.zscore_weight_pct` to accurately describe their role as minimum weight threshold fractions and how they blend reference vs. z-score expected weights
- Add `uv.lock` to `.gitignore`