### PR TITLE
Cap REST API page size to prevent unbounded queries

### DIFF
--- a/alyx/alyx/base.py
+++ b/alyx/alyx/base.py
@@ -26,6 +26,7 @@ from django_filters import rest_framework as filters
 from rest_framework.views import exception_handler
 from rest_framework import serializers
 from rest_framework import permissions
+from rest_framework.pagination import LimitOffsetPagination
 from dateutil.parser import parse
 from reversion.admin import VersionAdmin
 from alyx import __version__ as version
@@ -600,6 +601,15 @@ class BaseSerializerEnumField(serializers.Field):
             raise serializers.ValidationError("Invalid " + self.field_name + ", choices are: " +
                                               ', '.join([ch[1] for ch in self.choices]))
         return status[0][0]
+
+
+class LimitedLimitOffsetPagination(LimitOffsetPagination):
+    """LimitOffsetPagination with a hard cap on the requested page size.
+
+    Prevents a single request (e.g. `?limit=5000`) from materializing an
+    unbounded number of rows and their prefetched relations in memory.
+    """
+    max_limit = 1000
 
 
 def rest_filters_exception_handler(exc, context):

--- a/alyx/data/tests_rest.py
+++ b/alyx/data/tests_rest.py
@@ -243,6 +243,16 @@ class APIDataTests(BaseTests):
         r = self.client.get(reverse('dataset-list') + '?date=2018-01-01')
         self.assertTrue(len(self.ar(r, 200)) == 2)
 
+    def test_pagination_max_limit(self):
+        # A request for an unbounded `?limit=` must not materialize an arbitrary number of
+        # rows (and their prefetched relations) in memory; see LimitedLimitOffsetPagination.
+        Dataset.objects.bulk_create(
+            [Dataset(name=f'paginated-dataset-{i}.npy') for i in range(1500)])
+        r = self.client.get(reverse('dataset-list') + '?limit=5000')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.data['count'], 1500)
+        self.assertEqual(len(r.data['results']), 1000)
+
     def test_register_files(self):
         # create 4 repositories, 2 per lab
         self.post(reverse('datarepository-list'), {'name': 'dra1', 'hostname': 'hosta1'})

--- a/deploy/docker/settings-deploy.py
+++ b/deploy/docker/settings-deploy.py
@@ -205,7 +205,7 @@ REST_FRAMEWORK = {
     },
     'DEFAULT_FILTER_BACKENDS': ('django_filters.rest_framework.DjangoFilterBackend',),
     'STRICT_JSON': False,
-    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    'DEFAULT_PAGINATION_CLASS': 'alyx.base.LimitedLimitOffsetPagination',
     'EXCEPTION_HANDLER': 'alyx.base.rest_filters_exception_handler',
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
     'PAGE_SIZE': 250,


### PR DESCRIPTION
Caps the DRF pagination `limit` at 1000 (`LimitedLimitOffsetPagination`). Previously a client could request `?limit=5000` (or higher), and parallel requests like this OOM-killed openalyx.

Fixes int-brain-lab/iblalyx#151