### PR TITLE
Register file validation

### DIFF
--- a/alyx/data/tests_rest.py
+++ b/alyx/data/tests_rest.py
@@ -888,9 +888,11 @@ class APIDataTests(BaseTests):
         data = {'path': f'{self.subject}/2018-01-01/002/',
                 'filenames': 'test_prot/a.c.e2',
                 'name': 'drb1',  # this is the repository name
+                'filesizes': 14564,  # check handles non-list int value here
                 }
 
         d = self.ar(self.client.post(reverse('register-file'), data), 201)
+        self.assertEqual(d[0]['file_size'], 14564)
 
         # Check the same dataset to see if it is protected, should be unprotected
         # and get a status 200 response

--- a/alyx/data/tests_rest.py
+++ b/alyx/data/tests_rest.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 
 from alyx.base import BaseTests
 from data.models import Dataset, FileRecord, Download, Tag, DatasetType, DataFormat
+from misc.models import Lab
 from subjects.models import Subject
 
 
@@ -371,6 +372,96 @@ class APIDataTests(BaseTests):
         self.assertEqual(ds1.file_size, 45686)
         self.assertEqual(ds0.version, '1.1.1')
         self.assertEqual(ds1.version, '2.2.2')
+
+    def test_register_files_validation(self):
+        """Test that register files returns a 400 status code under different conditions."""
+        self.post(reverse('datarepository-list'), {'name': 'dra1', 'hostname': 'hosta1'})
+        self.post(reverse('lab-list'), {'name': 'laba', 'repositories': ['dra1']})
+
+        # Invalid repository name
+        data = {
+            "name":"invalid",
+            "path":'%s/2018-01-01/2/dir' % self.subject,
+            "filenames":["CognitionPlatform/subjects/qibao/2026-05-11/001/a.c.e1"],
+            "hashes":["8f85ec95a5387df4bb21e6b4eb3c3ca7f1f44bb3"],
+            "filesizes":3073962,
+            "labs":"dra1",
+            "created_by":"test"
+        }
+        r = self.post(reverse('register-file'), data)
+        self.ar(r, 400)
+
+        # Invalid data repository hostname
+        with self.subTest('Invalid data repository hostname'):
+            data = {
+                'path': '%s/2018-01-01/2/dir' % self.subject,
+                'filenames': 'a.b.e1',
+                'hostname': 'does-not-exist',
+            }
+            r = self.post(reverse('register-file'), data)
+            self.assertEqual(400, r.status_code, r.data)
+
+        # Non-existent lab
+        with self.subTest('Invalid lab name'):
+            data = {
+                'path': '%s/2018-01-01/2/dir' % self.subject,
+                'filenames': 'a.b.e1',
+                'name': 'dr',
+                'labs': 'does-not-exist',
+            }
+            r = self.post(reverse('register-file'), data)
+            self.assertEqual(400, r.status_code, r.data)
+
+        # Invalid ALF path: revision folder is not the last path segment
+        with self.subTest('Invalid ALF path (misplaced revision)'):
+            data = {
+                'path': '%s/2018-01-01/2/#v1#/sub' % self.subject,
+                'filenames': 'a.b.e1',
+                'name': 'dr',
+            }
+            r = self.post(reverse('register-file'), data)
+            self.assertEqual(400, r.status_code, r.data)
+
+        # Dataset.full_clean validation error (hash exceeds the 64 character field length)
+        with self.subTest('Dataset field validation error (hash too long)'):
+            data = {
+                'path': '%s/2018-01-01/2/dir' % self.subject,
+                'filenames': 'a.d.e1',
+                'name': 'dr',
+                'hashes': 'a' * 65,
+            }
+            r = self.post(reverse('register-file'), data)
+            self.assertEqual(400, r.status_code, r.data)
+
+        # FileRecord.full_clean validation error (relative_path contains a colon)
+        with self.subTest('FileRecord field validation error (invalid relative_path)'):
+            data = {
+                'path': '%s/2018-01-01/2/dir' % self.subject,
+                'filenames': 'a.c.x:y.e1',
+                'name': 'dr',
+            }
+            r = self.post(reverse('register-file'), data)
+            self.assertEqual(400, r.status_code, r.data)
+
+        # FileRecord unique_together violation: two different datasets (distinguished by
+        # object_id) registered to the same repository end up with the same relative_path
+        with self.subTest('FileRecord unique constraint violation'):
+            self.ar(self.post(reverse('lab-list'), {'name': 'labcollide1'}), 201)
+            self.ar(self.post(reverse('lab-list'), {'name': 'labcollide2'}), 201)
+            lab1 = Lab.objects.get(name='labcollide1')
+            lab2 = Lab.objects.get(name='labcollide2')
+            data = {
+                'path': 'Subjects/collide',
+                'filenames': 'a.b.e1',
+                'name': 'dra1',
+                'content_type': 'lab',
+                'object_id': str(lab1.pk),
+            }
+            r = self.post(reverse('register-file'), data)
+            self.ar(r, 201)
+            data['object_id'] = str(lab2.pk)
+            r = self.post(reverse('register-file'), data)
+            self.assertEqual(400, r.status_code, r.data)
 
     def test_qc_validation(self):
         # this tests the validation of dataset QC outcomes
@@ -946,7 +1037,7 @@ class APIDataTests(BaseTests):
 
     def test_register_aggregate(self):
         """Test endpoint for registering a dataset aggregated accross sessions.
-        
+
         Such datasets are associated to a model via a generic foreign key, and the relative
         path does not include the session pattern.
         """

--- a/alyx/data/tests_rest.py
+++ b/alyx/data/tests_rest.py
@@ -209,7 +209,8 @@ class APIDataTests(BaseTests):
 
         # Now attempt to delete the protected dataset
         r = self.client.delete(reverse('dataset-detail', args=[did]), data)
-        self.assertRegex(self.ar(r, 403), 'protected')
+        response = self.ar(r, 403)
+        self.assertRegex(response.get('detail') or '', 'protected')
 
     def test_dataset_date_filter(self):
         # create 2 datasets with different dates
@@ -1055,6 +1056,8 @@ class APIDataTests(BaseTests):
         }
         r = self.client.post(reverse('register-file'), data)
         self.ar(r, 201)
+        # Expect subject field to be populated when content_type == 'subject'
+        self.assertEqual(r.data[0]['subject'], self.subject)
         fr = FileRecord.objects.filter(dataset=Dataset.objects.get(name='a.a.e1'))
         self.assertTrue(fr.count() == 1)
         # Should support app label in content type

--- a/alyx/data/transfers.py
+++ b/alyx/data/transfers.py
@@ -7,6 +7,8 @@ import time
 from pathlib import Path, PurePosixPath, PurePath
 
 from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError
 from django.db.models import Case, When, Count, Q, F
 import globus_sdk
 import numpy as np
@@ -336,7 +338,12 @@ def _create_dataset_file_records(
     if file_size is not None:
         dataset.file_size = file_size
     # Validate the fields.
-    dataset.full_clean()
+    try:
+        dataset.full_clean()
+    except ValidationError as e:
+        data = {'status_code': 400,
+                'detail': f'Invalid dataset "{relative_path}": {e}'}
+        return None, Response(data=data, status=400)
     dataset.save()
 
     # Create one file record per repository.
@@ -344,13 +351,26 @@ def _create_dataset_file_records(
     for repo in repositories:
         exists = repo in exists_in
         # Do not create a new file record if it already exists.
-        fr, is_new = FileRecord.objects.get_or_create(
-            dataset=dataset, data_repository=repo, relative_path=relative_path.as_posix())
+        try:
+            fr, is_new = FileRecord.objects.get_or_create(
+                dataset=dataset, data_repository=repo, relative_path=relative_path.as_posix())
+        except IntegrityError:
+            data = {'status_code': 400,
+                    'detail': (f'A file record for "{relative_path}" already exists on '
+                              f'repository "{repo.name}" for a different dataset.')}
+            return None, Response(data=data, status=400)
         if is_new or is_patched:
             fr.exists = exists
             fr.json = None  # this is important if a dataset is patched during an ongoing transfer
         # Validate the fields.
-        fr.full_clean()
+        try:
+            fr.full_clean()
+        except ValidationError as e:
+            if is_new:
+                fr.delete()
+            data = {'status_code': 400,
+                    'detail': f'Invalid file record "{relative_path}": {e}'}
+            return None, Response(data=data, status=400)
         fr.save()
 
     return dataset, None

--- a/alyx/data/views.py
+++ b/alyx/data/views.py
@@ -446,7 +446,7 @@ class RegisterFileViewSet(mixins.CreateModelMixin,
         Endpoint to create and register a dataset and file record through the REST API.
 
         The session is retrieved by the ALF convention in the relative path, so this field has to
-        match the format Subject/Date/Number as shown below, unless 
+        match the format Subject/Date/Number as shown below, unless
 
         The set of repositories are given through the labs. The lab is by default the subject lab,
         but if it is specified, it overrides the subject lab entirely.
@@ -484,7 +484,7 @@ class RegisterFileViewSet(mixins.CreateModelMixin,
                'projects': 'alyx_lab_name',  # optional, alias of lab field above
               }
         ```
-        
+
         For registering data that is not associated with a session, the following fields should be
         provided:
         ```python
@@ -505,12 +505,16 @@ class RegisterFileViewSet(mixins.CreateModelMixin,
         # get the concerned repository using the name/hostname combination
         name = request.data.get('name', None)
         hostname = request.data.get('hostname', None)
-        if name:
-            repo = DataRepository.objects.get(name=name)
-        elif hostname:
-            repo = DataRepository.objects.get(hostname=hostname)
-        else:
-            repo = None
+        repo = None
+        try:
+            if name:
+                repo = DataRepository.objects.get(name=name)
+            elif hostname:
+                repo = DataRepository.objects.get(hostname=hostname)
+        except DataRepository.DoesNotExist:
+            data = {'status_code': 400, 'detail': 'The specified repository does not exist.'}
+            return Response(data=data, status=400)
+
         exists_in = (repo,)
 
         rel_dir_path = request.data.get('path', '')
@@ -579,8 +583,7 @@ class RegisterFileViewSet(mixins.CreateModelMixin,
             try:
                 model.objects.get(pk=object_id)
             except (model.DoesNotExist, ValidationError):
-                data = {'status_code': 400,
-                        'detail': f'Invalid object ID: {object_id}'}
+                data = {'status_code': 400, 'detail': f'Invalid object ID: {object_id}'}
                 return Response(data=data, status=400)
             # For aggregate datasets the repository must be specified,
             # as we cannot retrieve it from the session subject
@@ -626,10 +629,14 @@ class RegisterFileViewSet(mixins.CreateModelMixin,
             projects = request.data.get('projects', [])
             if isinstance(projects, str):
                 projects = projects.split(',')
-            labs = [Lab.objects.get(name=lab) for lab in labs + projects if lab]
-            
+            try:
+                labs = [Lab.objects.get(name=lab) for lab in labs + projects if lab]
+            except Lab.DoesNotExist:
+                data = {'status_code': 400, 'detail': 'One or more of the specified labs do not exist.'}
+                return Response(data=data, status=400)
+
             repositories = _get_repositories_for_labs(labs or [subject.lab], server_only=server_only)
-        
+
         if repo and repo not in repositories:
             repositories += [repo]
         if server_only:

--- a/alyx/data/views.py
+++ b/alyx/data/views.py
@@ -8,6 +8,8 @@ from rest_framework import generics, viewsets, mixins, serializers
 from rest_framework.response import Response
 import django_filters
 
+from iblutil.util import ensure_list
+
 from alyx.base import BaseFilterSet, rest_permission_classes
 from experiments.models import ProbeInsertion
 from subjects.models import Subject, Project
@@ -544,6 +546,7 @@ class RegisterFileViewSet(mixins.CreateModelMixin,
         filesizes = request.data.get('filesizes', [None] * len(filenames))
         if isinstance(filesizes, str):
             filesizes = filesizes.split(',')
+        filesizes = [int(f) if f is not None else None for f in ensure_list(filesizes)]
 
         # qc if provided
         qcs = request.data.get('qc', [None] * len(filenames)) or 'NOT_SET'

--- a/alyx/data/views.py
+++ b/alyx/data/views.py
@@ -239,8 +239,8 @@ class DatasetDetail(generics.RetrieveUpdateDestroyAPIView):
             return super().delete(request, *args, **kwargs)
         except models.ProtectedError as e:
             # Return Forbidden response with dataset name and list of protected tags associated
-            err_msg, _ = e.args
-            return Response(e.args[0], 403)
+            data = {'status_code': 403, 'detail': e.args[0]}
+            return Response(data, 403)
 
 
 # FileRecord
@@ -297,11 +297,17 @@ def _make_dataset_response(dataset):
         }
         for fr in FileRecord.objects.filter(dataset=dataset)]
 
+    subject = None
+    if dataset.session:
+        subject = dataset.session.subject.nickname
+    elif dataset.content_type.model == 'subject':
+        subject = dataset.content_object.nickname
+
     out = {
         'id': dataset.pk,
         'name': dataset.name,
         'file_size': dataset.file_size,
-        'subject': dataset.session.subject.nickname if dataset.session else None,
+        'subject': subject,
         'created_by': dataset.created_by.username,
         'created_datetime': dataset.created_datetime,
         'dataset_type': getattr(dataset.dataset_type, 'name', ''),


### PR DESCRIPTION
Handles the following issues within the register-file endpoint to return a 400 status:

- int file size for single file registrations
- invalid repository name
- invalid repository hostname
- non-existent lab
- invalid ALF path
- Dataset Django validation error
- FileRecord Django validation error
- FileRecord unique together violation