### PR TITLE
Fix Docker Hub secret names in build-image.yml

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -58,8 +58,8 @@ jobs:
         if: ${{ !startsWith(github.ref_name, 'dev') }}
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Push images
         if: ${{ !startsWith(github.ref_name, 'dev') }}


### PR DESCRIPTION
## Summary
- The 3.6.0 release build (dispatched by release.yml) failed at "Log in to Docker Hub" with "Username and password required".
- The workflow referenced `secrets.DOCKERHUB_USERNAME`/`secrets.DOCKERHUB_TOKEN`, but the repo's actual secrets are named `DOCKER_HUB_USERNAME`/`DOCKER_HUB_ACCESS_TOKEN` (confirmed via `gh secret list`).
- Build and smoke test both passed; only the push step was blocked.

## Test plan
- [ ] CI green
- [ ] After merge, re-dispatch build-image.yml against the existing 3.6.0 tag and confirm push succeeds