### PR TITLE
Correct file record path for aggregate datasets with revision

### DIFF
--- a/alyx/data/tests.py
+++ b/alyx/data/tests.py
@@ -341,7 +341,7 @@ class TestTransfers(TestCase):
         expected = {
             'full_path': 'Subjects/cortexlab/SP044/obj.attr.ext',
             'filename': filenames[0],
-            'rel_dir_path': relative_path,
+            'rel_dir_path': '',  # entire dir path captured by collection and revision
             'collection': relative_path,
             'revision': None,
             'relation': 'Subjects',
@@ -349,7 +349,7 @@ class TestTransfers(TestCase):
         }
         self.assertDictEqual(dataset_path_parsed[0], expected)
         self.assertEqual(dataset_path_parsed[1]['revision'], '2020-01-01')
-        
+
         # Check handles no collection and no revision
         dataset_path_parsed, resp = f(filenames, '')
         expected = [
@@ -365,7 +365,7 @@ class TestTransfers(TestCase):
             {
                 'full_path': filenames[1],
                 'filename': filenames[0],
-                'rel_dir_path': '#2020-01-01#',
+                'rel_dir_path': '',
                 'collection': None,
                 'revision': '2020-01-01',
                 'identifier': None,

--- a/alyx/data/tests_rest.py
+++ b/alyx/data/tests_rest.py
@@ -1,5 +1,6 @@
 import datetime
 from pathlib import PurePosixPath
+from unittest import mock
 import uuid
 
 from django.contrib.contenttypes.models import ContentType
@@ -8,6 +9,7 @@ from django.urls import reverse
 
 from alyx.base import BaseTests
 from data.models import Dataset, FileRecord, Download, Tag, DatasetType, DataFormat, DataNotice
+from data.views import DatasetList
 from misc.models import Lab
 from subjects.models import Subject
 
@@ -365,11 +367,14 @@ class APIDataTests(BaseTests):
         # A request for an unbounded `?limit=` must not materialize an arbitrary number of
         # rows (and their prefetched relations) in memory; see LimitedLimitOffsetPagination.
         Dataset.objects.bulk_create(
-            [Dataset(name=f'paginated-dataset-{i}.npy') for i in range(1500)])
-        r = self.client.get(reverse('dataset-list') + '?limit=5000')
-        self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.data['count'], 1500)
-        self.assertEqual(len(r.data['results']), 1000)
+            Dataset(name=f'paginated-dataset-{i}.npy') for i in range(15))
+        # Patch the cap directly so the test doesn't depend on whatever max_limit happens
+        # to be configured (e.g. the default of 1000) in the settings used to run it.
+        with mock.patch.object(DatasetList.pagination_class, 'max_limit', 10):
+            r = self.client.get(reverse('dataset-list') + '?limit=100')
+            self.assertEqual(r.status_code, 200)
+            self.assertEqual(r.data['count'], 15)
+            self.assertEqual(len(r.data['results']), 10)
 
     def test_register_files(self):
         # create 4 repositories, 2 per lab
@@ -1212,6 +1217,15 @@ class APIDataTests(BaseTests):
         r = self.client.post(reverse('register-file'), data)
         self.ar(r, 403)
         self.assertRegex(r.data['detail'], rf'Dataset {str(dataset.pk)} is protected, cannot patch')
+
+        # Test with a revision
+        data['filenames'] = '#2026-01-01#/a.a.e1'
+        r = self.client.post(reverse('register-file'), data)
+        d, = self.ar(r, 201)
+        self.assertEqual(d['collection'], data['path'])
+        self.assertEqual(d['revision'], data['filenames'][1:11])
+        file_record_paths = {x['relative_path'] for x in d['file_records']}
+        self.assertEqual(file_record_paths, {data['path'] + '/' + data['filenames']})
 
         # Test some validation
         del data['content_type']

--- a/alyx/data/transfers.py
+++ b/alyx/data/transfers.py
@@ -215,9 +215,9 @@ def _get_name_collection_revision(file, rel_dir_path):
 
 def get_aggregate_collection_revision(files, rel_dir_path):
     """Parse the path of a dataset not associated to a session.
-    
+
     This is less strict than `_get_name_collection_revision`.
-    
+
     By convention, the pattern is this: relation/identifier/(revision)/dataset
     For example: Subjects/cortexlab/SP044/#2020-01-01#/obj.attr.ext
                  Tags/2026_Q1_Wang_Yu_et_al/obj.attr.ext
@@ -230,12 +230,12 @@ def get_aggregate_collection_revision(files, rel_dir_path):
         info = regex(spec=COLLECTION_SPEC).match(_rel_dir_path + '/').groupdict()
         info['full_path'] = fullpath.as_posix()
         info['filename'] = fullpath.name
-        info['rel_dir_path'] = _rel_dir_path
+        info['rel_dir_path'] = ''  # no session path; full path should be captured by collection/revision
         info['relation'] = info['identifier'] = None
         if info['collection']:
             if '/' in info['collection']:
                 # This is just convention and is not enforced
-                info['relation'], info['identifier'] = info['collection'].split('/', 1)                    
+                info['relation'], info['identifier'] = info['collection'].split('/', 1)
         # Check that collection (if present) was captured correctly
         expected_len = 0 if not info['collection'] else len(info['collection'].split('/'))
         expected_len += int(bool(info['revision']))


### PR DESCRIPTION
Additionally, corrected pagination limit test to be independent of settings