### PR TITLE
Scoped delete_zygosity_rule post delete hook

### DIFF
--- a/alyx/subjects/models.py
+++ b/alyx/subjects/models.py
@@ -892,10 +892,9 @@ class ZygosityFinder(object):
             self._create_zygosity(subject, allele, z, force=force)
 
 
-@receiver(post_delete)
+@receiver(post_delete, sender=ZygosityRule)
 def delete_zygosity_rule(sender, instance, **kwargs):
-    if isinstance(instance, ZygosityRule):
-        _update_zygosities(instance.line, instance.sequence0)
+    _update_zygosities(instance.line, instance.sequence0)
 
 
 class AlleleManager(models.Manager):


### PR DESCRIPTION
By default this post delete hook was registered to all db models, including Datasets. This made bulk deletes slow and memory intensive as all objects were instantiated by Django before delete. Now this hook is only registered to ZygosityRule, as intended.