### PR TITLE
3.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stacks while reporting 174, as the list was ordered by `slices__name` and so joined the slices
   into the query. The stacks are ordered by their own fields now and the slices within each stack
   by the prefetch.
+- Admin no longer fails to start with djangorestframework >= 3.18
 
 ### Added
 
@@ -65,6 +66,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   than before this release. Several names, or a `dataset_qc_lte` below WARNING, keep the grouped
   count, both being cases where the semi-join measured no better or worse. The insertions and
   fields-of-view filters are not special-cased, measuring the same either way.
+
+### Changed
+- The custom admin site is now installed through `alyx.apps.AlyxAdminConfig` instead of by
+  reassigning `django.contrib.admin.site`. **Deployments must replace `'django.contrib.admin'`
+  with `'alyx.apps.AlyxAdminConfig'` in their `INSTALLED_APPS`**, otherwise the stock Django
+  admin index is served in place of the Alyx one. `alyx.base.mysite` is gone; use
+  `django.contrib.admin.site`, which now refers to the site Alyx serves.
+- Groups are administered through `django.contrib.auth`'s `GroupAdmin` rather than a bare
+  `ModelAdmin`, so group permissions get the two-pane selector
 
 ## [3.6.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   main query, which made them 3-174x faster.
 - `tag` filter on the fields-of-view REST endpoint. `FOVFilter` had a `filter_tag` method but
   never declared the filter that routes to it, so `/fields-of-view?tag=` was silently ignored.
+- `dataset_qc_lte` REST filter returned sessions and insertions once per matching dataset, so the
+  rows repeated across the paginated response and the count was the number of (row, dataset)
+  pairs: `/sessions?dataset_qc_lte=WARNING` reported 3,234,065 of 94,594 sessions.
+- `atlas_name`, `atlas_acronym` and `atlas_id` REST filters returned a session once per insertion
+  recording the region, and likewise an imaging stack once per slice.
+- The `dataset_types`, `datasets`, `dataset_qc_lte` and `atlas_*` REST filters now count and match
+  in a subquery instead of joining and grouping over the full row, making them up to 3.5x faster
+  (`/sessions?datasets=` 55 s to 16 s, `/chronic-insertions?atlas_acronym=` 0.7 s to 0.01 s).
+  `/insertions?tag=&dataset_qc_lte=` previously timed out, as the two joins multiplied.
+- The `datasets` REST filter counted the matching datasets rather than the distinct names on the
+  insertions and fields-of-view endpoints, so a row holding two datasets of one requested name
+  passed as having two different ones: `/insertions?datasets=` now agrees with `/sessions?datasets=`.
+  One name matches several datasets across collections and revisions for 142,624 (session, name)
+  and 50,078 (insertion, name) pairs, so this over-returned by ~4x on affected queries.
+- A dataset name repeated in a `datasets` REST filter, e.g. `?datasets=obj.attr.npy,obj.attr.npy`,
+  returned nothing at all rather than the rows having that dataset.
+- The chronic insertions REST list eagerly loaded its nested probe insertions while serialising
+  each row, which discarded the prefetched result and cost two queries per chronic insertion:
+  `/chronic-insertions` issued 329 queries for 176 rows, and now issues 4 regardless of the number
+  of rows (1.7x faster overall, 2.3x less time in the database).
+- The projects of a session, and the probe insertions of a chronic insertion, are now serialised in
+  a defined order. `Project` has no `Meta.ordering` and insertions of one chronic insertion often
+  share a session start time and name, so the database was free to return either in any order.
+- The sessions, insertions, fields-of-view and chronic insertions REST lists are now totally
+  ordered, so a page is the same from one request to the next. 916 sessions share a start time with
+  another and 120 insertions share a session start time and name, and rows tied that way came back
+  in a different order each request; `/chronic-insertions` had no ordering at all. The keys are
+  now `(-start_time, number, subject, pk)` for sessions and `(-session start_time, name, subject,
+  session number, pk)` for insertions and fields of view, the primary key being what makes them
+  total: `Session` and `ChronicInsertion` declare no uniqueness, and the insertion constraint is on
+  (session, name), which does not separate two sessions sharing a start time.
+- `/imaging-stacks` returned a stack once per slice, serving 250 rows covering 162 of the 174
+  stacks while reporting 174, as the list was ordered by `slices__name` and so joined the slices
+  into the query. The stacks are ordered by their own fields now and the slices within each stack
+  by the prefetch.
+
+### Added
+
+- `dataset_qc_lte` filter on the fields-of-view REST endpoint, matching the sessions and probe
+  insertions endpoints. The `datasets` filter there now applies the QC bound too, as it does on
+  those endpoints, rather than ignoring it.
+- Index on `data_dataset.name`, which the `?datasets=` REST filters look up and which had no index
+  (23 MB; deduplicated, as a few hundred names repeat across the table). Built concurrently, as
+  the table is continuously written. `/insertions?datasets=` is 7x faster, but note
+  `/sessions?datasets=` with two or more names is ~1.3x slower, as the planner switches from a
+  parallel sequential scan to a bitmap scan past roughly 5% of the table.
+- A single dataset name in the sessions `datasets` REST filter is now matched with one Exists
+  semi-join anchored on the session, rather than gathering every dataset of that name in the table
+  to group them: `/sessions?datasets=` with one name is 1.8x faster (9.9 s to 5.4 s), and 8x faster
+  than before this release. Several names, or a `dataset_qc_lte` below WARNING, keep the grouped
+  count, both being cases where the semi-join measured no better or worse. The insertions and
+  fields-of-view filters are not special-cased, measuring the same either way.
 
 ## [3.6.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.4]
+
+### Fixed
+
+- Sessions and probe insertions `tag` REST filters no longer join the datasets table into the
+  main query, which made them 3-174x faster.
+- `tag` filter on the fields-of-view REST endpoint. `FOVFilter` had a `filter_tag` method but
+  never declared the filter that routes to it, so `/fields-of-view?tag=` was silently ignored.
+
 ## [3.6.3]
 
 ### Fixed

--- a/alyx/actions/fixtures/actions.proceduretype.json
+++ b/alyx/actions/fixtures/actions.proceduretype.json
@@ -239,7 +239,7 @@
  "fields": {
   "name": "Tail Vein Injection",
   "json": null,
-  "description": "To be performed without anaesthesia by a trained personnel (Angela from BSU is the trained and competent person to perform this for us)."
+  "description": "To be performed without anaesthesia by a trained personnel."
  }
 },
 {
@@ -292,6 +292,15 @@
  "pk": "a00737fa-7ec1-48c1-ad7c-08529712adcb",
  "fields": {
   "name": "Fiber photometry",
+  "json": null,
+  "description": ""
+ }
+},
+{
+ "model": "actions.proceduretype",
+ "pk": "0c731d5f-21f0-428e-86ea-f6a8f4c61695",
+ "fields": {
+  "name": "Recording under general anaesthesia",
   "json": null,
   "description": ""
  }

--- a/alyx/actions/serializers.py
+++ b/alyx/actions/serializers.py
@@ -137,10 +137,14 @@ class SessionListSerializer(BaseActionSerializer):
 
     @staticmethod
     def setup_eager_loading(queryset):
-        """ Perform necessary eager loading of data to avoid horrible performance."""
+        """ Perform necessary eager loading of data to avoid horrible performance.
+
+        The sort key is a total order. Subject, start time and number together happen
+        to be unique today but are not guaranteed to stay so.
+        """
         queryset = queryset.select_related('subject', 'lab')
         queryset = queryset.prefetch_related('projects', 'procedures')
-        return queryset.order_by('-start_time')
+        return queryset.order_by('-start_time', 'number', 'subject__nickname', 'pk')
 
     class Meta:
         model = Session

--- a/alyx/actions/tests_rest.py
+++ b/alyx/actions/tests_rest.py
@@ -16,7 +16,7 @@ from actions.models import (
     Surgery,
     ProcedureType,
 )
-from data.models import Dataset, DatasetType, FileRecord, DataRepository
+from data.models import Dataset, DatasetType, FileRecord, DataRepository, Tag
 
 
 class APIActionsBaseTests(BaseTests):
@@ -94,6 +94,44 @@ class APIActionsSessionsTests(APIActionsBaseTests):
             self.client.get(reverse("session-list") + f"?projects={self.projectY.name}")
         )
         self.assertEqual(len(d), 1)
+
+    def test_sessions_tag(self):
+        """Sessions are matched via the tags of their datasets, without duplicating rows."""
+        tag = Tag.objects.create(name="2020_Q1_Test_et_al")
+        other_tag = Tag.objects.create(name="unrelated_tag")
+        ses1, ses2, ses3 = (
+            Session.objects.create(subject=self.subject, lab=self.lab01, number=i + 1)
+            for i in range(3)
+        )
+        ses1.projects.set([self.projectX, self.projectY])
+        # two tagged datasets on the same session must not duplicate it in the response
+        for name in ("obj.attr.npy", "obj.times.npy"):
+            Dataset.objects.create(session=ses1, name=name).tags.add(tag)
+        Dataset.objects.create(session=ses2, name="obj.attr.npy").tags.add(tag, other_tag)
+        Dataset.objects.create(session=ses3, name="obj.attr.npy").tags.add(other_tag)
+        # a tagged dataset with no session must not affect the filter
+        Dataset.objects.create(name="aggregate.attr.npy").tags.add(tag)
+
+        expected = sorted([str(ses1.pk), str(ses2.pk)])
+        d = self.ar(self.client.get(reverse("session-list") + f"?tag={tag.name}"))
+        self.assertEqual(expected, sorted(x["id"] for x in d))
+
+        # the lookup is a case-insensitive partial match on the tag name
+        d = self.ar(self.client.get(reverse("session-list") + "?tag=test_ET_al"))
+        self.assertEqual(expected, sorted(x["id"] for x in d))
+
+        d = self.ar(self.client.get(reverse("session-list") + f"?tag={other_tag.name}"))
+        self.assertEqual(sorted([str(ses2.pk), str(ses3.pk)]), sorted(x["id"] for x in d))
+
+        d = self.ar(self.client.get(reverse("session-list") + "?tag=no_such_tag"))
+        self.assertEqual([], d)
+
+        # combining with another many-to-many filter must not duplicate rows either: the
+        # projects lookup matches both of ses1's projects
+        d = self.ar(
+            self.client.get(reverse("session-list") + f"?tag={tag.name}&projects=project")
+        )
+        self.assertEqual([str(ses1.pk)], [x["id"] for x in d])
 
     def test_sessions(self):
         a_dict4json = {

--- a/alyx/actions/tests_rest.py
+++ b/alyx/actions/tests_rest.py
@@ -133,6 +133,34 @@ class APIActionsSessionsTests(APIActionsBaseTests):
         )
         self.assertEqual([str(ses1.pk)], [x["id"] for x in d])
 
+    def test_sessions_dataset_filters_do_not_duplicate_sessions(self):
+        """A session is returned once however many of its datasets match the filter.
+
+        These filters used to join the datasets into the session query, returning the session once
+        per matching dataset and reporting the number of (session, dataset) pairs as the count.
+        """
+        session = Session.objects.create(
+            subject=self.subject, lab=self.lab01, number=1)
+        dtype, _ = DatasetType.objects.get_or_create(name="spikes.times")
+        repo = DataRepository.objects.create(name="server", globus_is_personal=False)
+        # three datasets on the one session, all matching every filter below
+        for i in range(3):
+            dset = Dataset.objects.create(
+                session=session, name="spikes.times.npy", dataset_type=dtype, qc=30,
+                version=str(i))
+            FileRecord.objects.create(
+                dataset=dset, data_repository=repo, exists=True,
+                relative_path=f"{session.pk}/alf/#{i}#/spikes.times.npy")
+
+        url = reverse("session-list")
+        for query in ("?dataset_qc_lte=WARNING", "?dataset_types=spikes.times",
+                      "?datasets=spikes.times.npy"):
+            with self.subTest(query=query):
+                r = self.client.get(url + query)
+                self.assertEqual(200, r.status_code)
+                self.assertEqual(1, r.data["count"], "count must not be a pair count")
+                self.assertEqual([str(session.pk)], [x["id"] for x in r.data["results"]])
+
     def test_sessions(self):
         a_dict4json = {
             "String": "this is not a JSON",

--- a/alyx/actions/views.py
+++ b/alyx/actions/views.py
@@ -2,7 +2,7 @@ from datetime import timedelta, date, datetime
 from operator import itemgetter
 
 from django.contrib.postgres.fields import JSONField
-from django.db.models import Count, Q, F, ExpressionWrapper, FloatField, BooleanField
+from django.db.models import Count, Exists, Q, F, ExpressionWrapper, FloatField, OuterRef
 from django.db.models.deletion import Collector
 from django_filters.rest_framework.filters import CharFilter
 from django.http import HttpResponse
@@ -17,7 +17,7 @@ from rest_framework.views import APIView
 from one.alf.spec import QC
 
 from alyx.base import base_json_filter, BaseFilterSet, rest_permission_classes
-from data.models import Dataset
+from data.models import Dataset, FileRecord
 from subjects.models import Subject
 from experiments.views import _filter_qs_with_brain_regions
 from .water_control import water_control, to_date
@@ -288,43 +288,74 @@ class SessionFilter(BaseActionFilter):
         return base_json_filter('extended_qc', queryset, name, value)
 
     def filter_dataset_types(self, queryset, _, value):
+        """
+        returns sessions that have datasets of all of the given type(s)
+
+        The datasets are counted per session in a subquery instead of being joined into the session
+        query and grouped there: the GROUP BY then covers a single ID column rather than the full
+        session, subject and lab row.
+        """
         dtypes = value.split(',')
-        queryset = queryset.filter(data_dataset_session_related__dataset_type__name__in=dtypes)
-        queryset = queryset.annotate(
-            dtypes_count=Count('data_dataset_session_related__dataset_type', distinct=True))
-        queryset = queryset.filter(dtypes_count__gte=len(dtypes))
-        return queryset
+        sessions = (Dataset.objects
+                    .filter(dataset_type__name__in=dtypes, session__isnull=False)
+                    .values('session')
+                    .annotate(dtypes_count=Count('dataset_type__name', distinct=True))
+                    .filter(dtypes_count__gte=len(dtypes))
+                    .values_list('session', flat=True))
+        return queryset.filter(pk__in=sessions)
 
     def filter_datasets(self, queryset, _, value):
+        """
+        returns sessions that have all of the given dataset(s), present on a server repository
+
+        The file record check is an Exists semi-join rather than a join annotated with a boolean,
+        so a dataset is not returned once per file record.
+
+        For a single dataset name, and only while the QC bound is loose, the whole filter is one
+        Exists semi-join anchored on the session, which resolves through the datasets of that
+        session alone and stops at the first match. It is not used otherwise:
+
+        - with several names that form is no better, and is far worse on the insertions filter,
+          as every name adds a subquery that has to be probed for every row
+        - with a tight QC bound the early exit stops paying, because a session that has no
+          qualifying dataset is only ruled out once all of its datasets have been examined.
+          Measured against the grouped count below: 5.4 s vs 9.9 s at the default bound, but
+          17.8 s vs 9.5 s at PASS, where only half the sessions still qualify.
+        """
         # Note this may later be modified to include collections, e.g. ?datasets=alf/obj.attr.ext
         qc = QC.validate(self.request.query_params.get('dataset_qc_lte', QC.FAIL))
-        dataset_names = value.split(',')
-        queryset = queryset.filter(data_dataset_session_related__name__in=dataset_names)
-        dsets = Dataset.objects.filter(
-            session__in=queryset,
-            name__in=dataset_names,
-            qc__lte=qc,
-        ).annotate(
-            exists=ExpressionWrapper(
-                Q(
-                    file_records__data_repository__globus_is_personal=False,
-                    file_records__exists=True
-                ),
-                output_field=BooleanField()
-            )
-        ).filter(exists__gte=1)
-        sessions = dsets.values_list('session', flat=True).distinct().annotate(
-            dset_count=Count('name', distinct=True)).filter(dset_count__gte=len(dataset_names))
-        queryset = queryset.filter(pk__in=sessions.values_list('session')).distinct()
-        return queryset
+        dataset_names = sorted(set(value.split(',')))
+        online = FileRecord.objects.filter(
+            dataset=OuterRef('pk'), exists=True, data_repository__globus_is_personal=False)
+        if len(dataset_names) == 1 and qc >= QC.WARNING:
+            return queryset.filter(Exists(
+                Dataset.objects
+                .filter(session=OuterRef('pk'), name=dataset_names[0], qc__lte=qc)
+                .filter(Exists(online)))).distinct()
+        sessions = (Dataset.objects
+                    .filter(name__in=dataset_names, qc__lte=qc, session__isnull=False)
+                    .filter(Exists(online))
+                    .values('session')
+                    .annotate(dset_count=Count('name', distinct=True))
+                    .filter(dset_count__gte=len(dataset_names))
+                    .values_list('session', flat=True))
+        return queryset.filter(pk__in=sessions).distinct()
 
     def filter_dataset_qc_lte(self, queryset, _, value):
+        """
+        returns sessions with at least one dataset whose QC is at most the given value
+
+        An Exists semi-join, so a session is returned once no matter how many of its datasets
+        qualify. The previous join returned it once per qualifying dataset, which duplicated the
+        rows across the paginated response and inflated the reported count to the number of
+        (session, dataset) pairs.
+        """
         # If filtering on datasets too, `filter_datasets` handles both QC and Datasets
         if 'datasets' in self.request.query_params:
             return queryset
         qc = QC.validate(value)
-        queryset = queryset.filter(data_dataset_session_related__qc__lte=qc)
-        return queryset
+        return queryset.filter(
+            Exists(Dataset.objects.filter(session=OuterRef('pk'), qc__lte=qc)))
 
     def filter_performance_gte(self, queryset, name, perf):
         queryset = queryset.exclude(n_trials__isnull=True)

--- a/alyx/actions/views.py
+++ b/alyx/actions/views.py
@@ -253,10 +253,19 @@ class SessionFilter(BaseActionFilter):
     def filter_tag(self, queryset, name, value):
         """
         returns sessions that contain datasets tagged as
+
+        The matching sessions are resolved in a separate query rather than joining the datasets
+        into the session query. A tag typically covers tens of thousands of datasets but only a
+        few hundred sessions, and joining them in fans the session rows out by that ratio, then
+        forces the DISTINCT to deduplicate over the full (very wide) session row. Passing the
+        session IDs in as a literal list also keeps the query planner from re-planning this as a
+        correlated sub-plan over the whole session table, which it does once the outer query is
+        selective enough to look cheap.
         """
-        queryset = queryset.filter(
-            data_dataset_session_related__tags__name__icontains=value).distinct()
-        return queryset
+        session_ids = (Dataset.objects
+                       .filter(tags__name__icontains=value, session__isnull=False)
+                       .values_list('session', flat=True).distinct())
+        return queryset.filter(pk__in=list(session_ids)).distinct()
 
     def atlas(self, queryset, name, value):
         """

--- a/alyx/alyx/__init__.py
+++ b/alyx/alyx/__init__.py
@@ -1,1 +1,1 @@
-VERSION = __version__ = '3.6.3'
+VERSION = __version__ = '3.6.4'

--- a/alyx/alyx/apps.py
+++ b/alyx/alyx/apps.py
@@ -1,0 +1,16 @@
+from django.contrib.admin.apps import AdminConfig
+
+
+class AlyxAdminConfig(AdminConfig):
+    """Installs MyAdminSite as Django's default admin site.
+
+    This is the supported hook for replacing the admin site, and it must be used rather than
+    reassigning ``django.contrib.admin.site``: the ``@admin.register`` decorator resolves the
+    default site at import time via ``django.contrib.admin.sites.site``, so a reassignment is
+    invisible to it and any app registering that way (``django.contrib.auth``,
+    ``rest_framework.authtoken``, ...) would land on a site Alyx never serves.
+
+    ``INSTALLED_APPS`` lists this in place of ``django.contrib.admin``.
+    """
+
+    default_site = 'alyx.base.MyAdminSite'

--- a/alyx/alyx/base.py
+++ b/alyx/alyx/base.py
@@ -277,6 +277,18 @@ def get_admin_url(obj):
 
 
 class MyAdminSite(admin.AdminSite):
+    """The admin site Alyx serves.
+
+    Installed as Django's default site by alyx.apps.AlyxAdminConfig, so that
+    ``django.contrib.admin.site`` and the ``@admin.register`` decorator both refer to it.
+    """
+
+    site_header = 'Alyx'
+    site_title = 'Alyx'
+    site_url = None
+    index_title = f'Welcome to Alyx {version}'
+    enable_nav_sidebar = False
+
     def index(self, request, extra_context=None):
         category_list = _get_category_list(self.get_app_list(request))
         context = dict(
@@ -648,13 +660,3 @@ class BaseRestPublicPermission(permissions.BasePermission):
 def rest_permission_classes():
     permission_classes = (permissions.IsAuthenticated & BaseRestPublicPermission,)
     return permission_classes
-
-
-mysite = MyAdminSite()
-mysite.site_header = 'Alyx'
-mysite.site_title = 'Alyx'
-mysite.site_url = None
-mysite.index_title = f'Welcome to Alyx {version}'
-mysite.enable_nav_sidebar = False
-
-admin.site = mysite

--- a/alyx/alyx/urls.py
+++ b/alyx/alyx/urls.py
@@ -8,8 +8,6 @@ from drf_spectacular.views import SpectacularAPIView
 from alyx.views import SpectacularRedocViewCoreAPIDeprecation
 
 
-admin.site.site_header = 'Alyx'
-
 urlpatterns = [
     path('', include('misc.urls')),
     path('', include('experiments.urls')),

--- a/alyx/data/migrations/0024_dataset_data_dataset_name_idx.py
+++ b/alyx/data/migrations/0024_dataset_data_dataset_name_idx.py
@@ -1,0 +1,24 @@
+from django.contrib.postgres.operations import AddIndexConcurrently
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Index data_dataset.name, which the `?datasets=` REST filters look up.
+
+    Built concurrently: data_dataset is ~1.4 GB and continuously written by the ingest pipeline,
+    and a regular CREATE INDEX would hold an ACCESS EXCLUSIVE lock on it for the duration of the
+    build. Concurrent builds cannot run inside a transaction, hence atomic = False.
+    """
+
+    atomic = False
+
+    dependencies = [
+        ('data', '0023_datanotice'),
+    ]
+
+    operations = [
+        AddIndexConcurrently(
+            model_name='dataset',
+            index=models.Index(fields=['name'], name='data_dataset_name_idx'),
+        ),
+    ]

--- a/alyx/data/models.py
+++ b/alyx/data/models.py
@@ -361,6 +361,14 @@ class Dataset(BaseExperimentalData):
     qc = models.IntegerField(default=QC.NOT_SET, choices=QC_CHOICES,
                              help_text=' / '.join([str(q[0]) + ': ' + q[1] for q in QC_CHOICES]))
 
+    class Meta:
+        indexes = [
+            # `?datasets=` on the sessions, insertions and fields-of-view REST endpoints looks
+            # datasets up by name. Deduplication keeps this small (~23 MB for 3.2M rows) as the
+            # same few hundred names repeat throughout the table.
+            models.Index(fields=['name'], name='data_dataset_name_idx'),
+        ]
+
     @property
     def is_online(self):
         fr = self.file_records.filter(data_repository__globus_is_personal=False)

--- a/alyx/experiments/serializers.py
+++ b/alyx/experiments/serializers.py
@@ -106,10 +106,18 @@ class ChronicProbeInsertionListSerializer(serializers.ModelSerializer):
         """Perform necessary eager loading of data to avoid horrible performance.
 
         SessionListSerializer uses these related tables.
+
+        The projects and the insertions themselves are given a total order. Project has no
+        Meta.ordering, and insertions of one chronic insertion often share a session start time and
+        name, so without one the database is free to return either in any order and the same
+        request can serialise them differently from one call to the next. The sort key matches
+        ProbeInsertionListSerializer.
         """
         queryset = queryset.select_related('model', 'session', 'session__subject', 'session__lab')
-        queryset = queryset.prefetch_related('session__projects')
-        return queryset.order_by('-session__start_time', 'name')
+        queryset = queryset.prefetch_related(
+            Prefetch('session__projects', queryset=Project.objects.order_by('name')))
+        return queryset.order_by('-session__start_time', 'name',
+                                 'session__subject__nickname', 'session__number', 'pk')
 
     model = serializers.SlugRelatedField(read_only=True, slug_field='name')
     session_info = SessionListSerializer(read_only=True, source='session')
@@ -123,10 +131,16 @@ class ProbeInsertionListSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def setup_eager_loading(queryset):
-        """ Perform necessary eager loading of data to avoid horrible performance."""
+        """ Perform necessary eager loading of data to avoid horrible performance.
+
+        The sort key is a total order. Session start time and insertion name are not enough: the
+        unique constraint is on (session, name), so two insertions of the same name in two
+        different sessions that share a start time tie, which 120 insertions currently do.
+        """
         queryset = queryset.select_related('model', 'session', 'session__subject', 'session__lab')
         queryset = queryset.prefetch_related('session__projects', 'datasets')
-        return queryset.order_by('-session__start_time', 'name')
+        return queryset.order_by('-session__start_time', 'name',
+                                 'session__subject__nickname', 'session__number', 'pk')
 
     session = serializers.SlugRelatedField(
         read_only=False, required=False, slug_field='id',
@@ -190,10 +204,23 @@ class ChronicInsertionListSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def setup_eager_loading(queryset):
-        """ Perform necessary eager loading of data to avoid horrible performance."""
+        """ Perform necessary eager loading of data to avoid horrible performance.
+
+        The probe insertions are eagerly loaded here, through a Prefetch carrying the queryset
+        their serializer wants, rather than in that serializer. Applying select_related, order_by
+        or prefetch_related to `obj.probe_insertion.all()` while serializing a row discards the
+        prefetched result and re-queries, which cost one query per chronic insertion for the
+        insertions and another for their projects.
+
+        ChronicInsertion has neither Meta.ordering nor any uniqueness of its own, so without the
+        sort key below the rows come back in whatever order the database chooses.
+        """
         queryset = queryset.select_related('model', 'subject', 'lab')
-        queryset = queryset.prefetch_related('probe_insertion')
-        return queryset
+        queryset = queryset.prefetch_related(Prefetch(
+            'probe_insertion',
+            queryset=ChronicProbeInsertionListSerializer.setup_eager_loading(
+                ProbeInsertion.objects.all())))
+        return queryset.order_by('-start_time', 'subject__nickname', 'name', 'pk')
 
     subject = serializers.SlugRelatedField(
         read_only=False, required=False, slug_field='nickname',
@@ -207,13 +234,7 @@ class ChronicInsertionListSerializer(serializers.ModelSerializer):
         read_only=False, required=False, slug_field='name',
         queryset=Lab.objects.all(),
     )
-    probe_insertion = serializers.SerializerMethodField()
-
-    def get_probe_insertion(self, obj):
-        qs = ChronicProbeInsertionListSerializer.setup_eager_loading(obj.probe_insertion.all())
-        request = self.context.get('request', None)
-        ins = ChronicProbeInsertionListSerializer(qs, many=True, context={'request': request})
-        return ins.data
+    probe_insertion = ChronicProbeInsertionListSerializer(read_only=True, many=True)
 
     class Meta:
         model = ChronicInsertion
@@ -304,14 +325,19 @@ class FOVSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def setup_eager_loading(queryset):
-        """Perform necessary eager loading of data to avoid horrible performance."""
+        """Perform necessary eager loading of data to avoid horrible performance.
+
+        The primary key completes the sort key: as for probe insertions the unique constraint is on
+        (session, name), which leaves two fields of view of the same name in two sessions sharing a
+        start time tied. None are today, but nothing prevents it.
+        """
         queryset = queryset.select_related('imaging_type')
         # Apply eager loading to the nested location field
         location_qs = FOVLocationListSerializer.setup_eager_loading(FOVLocation.objects.all())
         queryset = queryset.prefetch_related(
             'datasets', Prefetch('location', queryset=location_qs)
         )
-        return queryset.order_by('-session__start_time', 'name')
+        return queryset.order_by('-session__start_time', 'name', 'pk')
 
     class Meta:
         model = FOV
@@ -324,11 +350,18 @@ class ImagingStackDetailSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def setup_eager_loading(queryset):
-        """Perform necessary eager loading of nested slices."""
+        """Perform necessary eager loading of nested slices.
+
+        The stacks are ordered by their own fields. Ordering them by `slices__name` joined the
+        slices into the query and so returned a stack once per slice: `/imaging-stacks` reported
+        174 stacks but served 250 rows covering 162 of them, since all but one stack has more than
+        one slice. The slices are ordered within each stack by the Prefetch queryset instead.
+        """
+        # TODO order slices by z values of FOVLocations where default_provenance is True
         slice_qs = FOVSerializer.setup_eager_loading(FOV.objects.filter(stack__isnull=False))
+        slice_qs = slice_qs.order_by('name', 'pk')
         queryset = queryset.prefetch_related(Prefetch('slices', queryset=slice_qs))
-        # TODO order by z values of FOVLocations where default_provenance is True
-        return queryset.order_by('slices__name')
+        return queryset.order_by('name', 'pk')
 
     class Meta:
         model = ImagingStack

--- a/alyx/experiments/tests_rest.py
+++ b/alyx/experiments/tests_rest.py
@@ -2,13 +2,15 @@ from random import random, choice, randint
 
 from django.contrib.auth import get_user_model
 from django.urls import reverse
-from django.db import transaction
+from django.db import connection, transaction
+from django.test.utils import CaptureQueriesContext
+from django.utils.timezone import now
 
 from alyx.base import BaseTests
 from actions.models import Session, ProcedureType
 from misc.models import Lab
 from subjects.models import Subject, Project
-from experiments.models import ProbeInsertion, ImagingType, FOV
+from experiments.models import ProbeInsertion, ImagingType, FOV, ImagingStack
 from data.models import Dataset, DatasetType, Tag
 
 
@@ -133,10 +135,11 @@ class APIProbeExperimentTests(BaseTests):
                          }
             url = reverse('probeinsertion-list')
             insertions.append(self.ar(self.post(url, insertion), 201))
-        
+
         probe_ins = self.ar(self.client.get(reverse('probeinsertion-list')), 200)
         self.assertEqual(probe_ins[0]['session_info']['id'], str(session.id))
-        self.assertEqual([x['name'] for x in probe_ins], ['probe00', 'probe01', 'probe02', 'probe00', 'probe01'])
+        self.assertEqual(['probe00', 'probe01', 'probe02', 'probe00', 'probe01'],
+                         [x['name'] for x in probe_ins])
 
     def test_probe_insertion_dataset_interaction(self):
         # First create two insertions and attach to session
@@ -193,6 +196,46 @@ class APIProbeExperimentTests(BaseTests):
         urlf = (reverse('dataset-list') + '?&probe_insertion=' + insertions[0]['id'])
         datasets = self.ar(self.client.get(urlf))
         self.assertTrue(len(datasets) == 2)
+
+    def test_chronic_insertion_list_query_count(self):
+        """The chronic insertions list costs a fixed number of queries, whatever its length.
+
+        Its nested probe insertions used to be eagerly loaded while serialising each row, which
+        discarded the prefetched result and cost two queries per chronic insertion.
+        """
+        url = reverse('chronicinsertion-list')
+
+        def add_chronic_insertion(i):
+            """a chronic insertion with two probe insertions on two sessions"""
+            ci = self.ar(self.post(url, {
+                'subject': self.session.subject.nickname, 'serial': f'1901910{i}',
+                'model': '3B2', 'name': f'probe{i:02}'}), 201)
+            for number in range(2):
+                session = Session.objects.create(
+                    subject=self.session.subject, number=10 * i + number)
+                session.projects.add(*self.session.projects.all())
+                self.ar(self.post(reverse('probeinsertion-list'), {
+                    'session': str(session.id), 'name': f'probe0{number}', 'model': '3B2',
+                    'chronic_insertion': ci['id'], 'serial': f'1901910{i}'}), 201)
+
+        def count_queries():
+            with CaptureQueriesContext(connection) as ctx:
+                r = self.client.get(url + '?limit=250')
+            self.assertEqual(200, r.status_code)
+            self.assertTrue(all(len(x['probe_insertion']) == 2 for x in r.data['results']))
+            return len(ctx.captured_queries), r.data['count']
+
+        add_chronic_insertion(0)
+        one, n_one = count_queries()
+        self.assertEqual(1, n_one)
+        for i in (1, 2, 3):
+            add_chronic_insertion(i)
+        several, n_several = count_queries()
+        self.assertEqual(4, n_several)
+
+        # the point of the eager loading: the same queries serve one row or many
+        self.assertEqual(one, several,
+                         f'{one} queries for 1 chronic insertion but {several} for 4')
 
     def test_probe_insertion_tag_filter(self):
         """Insertions are matched via the tags of their datasets, without duplicating rows."""
@@ -462,6 +505,99 @@ class APIProbeExperimentTests(BaseTests):
         self.assertEqual(len(d), 1)
         self.assertEqual(probe['id'], d[0]['id'])
 
+    def test_datasets_filter_counts_distinct_names(self):
+        """Several datasets sharing one name do not satisfy a request for several names.
+
+        A name routinely matches more than one dataset of an insertion, across collections and
+        revisions, so counting the datasets rather than the distinct names let an insertion
+        holding two copies of one requested name pass as having two different ones.
+        """
+        probe = self.ar(self.post(reverse('probeinsertion-list'), self.dict_insertion), 201)
+        dtype, _ = DatasetType.objects.get_or_create(name='channels.localCoordinates')
+        # two datasets of the same name, as a session has one per probe
+        for collection in ('alf/probe_00/pykilosort', 'alf/probe_00/iblsort'):
+            Dataset.objects.create(
+                session=self.session, name='channels.localCoordinates.npy',
+                dataset_type=dtype, collection=collection, qc=30)
+        insertion = ProbeInsertion.objects.get(pk=probe['id'])
+        self.assertEqual(2, insertion.datasets.count())
+
+        url = reverse('probeinsertion-list')
+        # the one name it does have is matched
+        d = self.ar(self.client.get(url + '?datasets=channels.localCoordinates.npy'))
+        self.assertEqual([probe['id']], [x['id'] for x in d])
+        # but it does not have both of these, so it must not be returned
+        q = '?datasets=channels.localCoordinates.npy,spikes.times.npy'
+        self.assertEqual([], self.ar(self.client.get(url + q)))
+        # a name repeated in the query asks for that one dataset, not for two of them
+        q = '?datasets=channels.localCoordinates.npy,channels.localCoordinates.npy'
+        self.assertEqual([probe['id']], [x['id'] for x in self.ar(self.client.get(url + q))])
+
+    def test_dataset_filters_do_not_duplicate_insertions(self):
+        """An insertion is returned once however many of its datasets match the filter.
+
+        Each of these filters used to join the datasets into the insertion query, returning the
+        insertion once per matching dataset and reporting the number of (insertion, dataset) pairs
+        as the count.
+        """
+        probe = self.ar(self.post(reverse('probeinsertion-list'), self.dict_insertion), 201)
+        dtype, _ = DatasetType.objects.get_or_create(name='spikes.times')
+        tag, _ = Tag.objects.get_or_create(name='tag_test')
+        # three datasets on the one insertion, all matching every filter below
+        for i in range(3):
+            dset = Dataset.objects.create(
+                session=self.session, name='spikes.times.npy', dataset_type=dtype,
+                collection='alf/probe_00', qc=30, revision=None, version=str(i))
+            dset.tags.add(tag)
+        insertion = ProbeInsertion.objects.get(pk=probe['id'])
+        self.assertEqual(3, insertion.datasets.count(), 'expected all three to be associated')
+
+        url = reverse('probeinsertion-list')
+        for query in ('?dataset_qc_lte=WARNING', '?dataset_types=spikes.times',
+                      '?datasets=spikes.times.npy', '?tag=tag_test'):
+            with self.subTest(query=query):
+                r = self.client.get(url + query)
+                self.assertEqual(200, r.status_code)
+                self.assertEqual(1, r.data['count'], 'count must not be a pair count')
+                self.assertEqual([probe['id']], [x['id'] for x in r.data['results']])
+
+    def test_atlas_filters_do_not_duplicate_rows(self):
+        """A session is returned once however many of its insertions are in the brain region.
+
+        The session branch of the brain region filter ORs two joins together with no DISTINCT, so
+        a session came back once per insertion recording the region -- which is most of them, as
+        sessions routinely have two probes.
+        """
+        insertions = []
+        for name in ('probe00', 'probe01'):
+            insertion = self.ar(self.post(reverse('probeinsertion-list'),
+                                          dict(self.dict_insertion, name=name)), 201)
+            insertions.append(insertion['id'])
+            # only one trajectory per provenance is allowed per insertion, and only the ephys
+            # aligned provenance (70) is considered by the filter
+            traj = self.ar(self.post(reverse('trajectoryestimate-list'), {
+                'probe_insertion': insertion['id'], 'x': -4521.2, 'y': 2415.0, 'z': 0,
+                'phi': 80, 'theta': 10, 'depth': 5000, 'roll': 0,
+                'provenance': 'Ephys aligned histology track'}), 201)
+            for axial in (20, 40, 60):
+                self.ar(self.post(reverse('channel-list'), {
+                    'x': 111.1, 'y': -222.2, 'z': 333.3, 'axial': axial, 'lateral': 40,
+                    'brain_region': 593,  # VISp1
+                    'trajectory_estimate': traj['id']}), 201)
+
+        for query in ('?atlas_acronym=VISp1', '?atlas_id=593', '?atlas_name=primary visual'):
+            with self.subTest(query=query):
+                r = self.client.get(reverse('session-list') + query)
+                self.assertEqual(200, r.status_code)
+                self.assertEqual(1, r.data['count'],
+                                 'the session must not be returned once per insertion')
+                self.assertEqual([str(self.session.pk)], [x['id'] for x in r.data['results']])
+                # both insertions are in the region, and each is returned exactly once
+                r = self.client.get(reverse('probeinsertion-list') + query)
+                self.assertEqual(200, r.status_code)
+                self.assertEqual(2, r.data['count'])
+                self.assertEqual(sorted(insertions), sorted(x['id'] for x in r.data['results']))
+
 
 class APIImagingExperimentTests(BaseTests):
     fixtures = ['experiments.brainregion.json', 'experiments.coordinatesystem.json']
@@ -542,6 +678,83 @@ class APIImagingExperimentTests(BaseTests):
         # First location in list should be default provenance = True
         self.assertEqual([True, False], [x['default_provenance'] for x in r[0]['location']])
         self.assertIn(355, r[0]['location'][0]['brain_region'])
+
+    def test_imaging_stack_list_one_row_per_stack(self):
+        """A stack is listed once however many slices it holds.
+
+        The list was ordered by `slices__name`, which joined the slices into the query and returned
+        the stack once per slice while the reported count stayed at the number of stacks.
+        """
+        stack = ImagingStack.objects.create(name='stack_00')
+        url = reverse('fieldsofview-list')
+        for name in ('FOV_02', 'FOV_00', 'FOV_01'):
+            fov = self.ar(self.post(url, dict(self.dict_fov, name=name)), 201)
+            # not queryset.update(): BaseQuerySet.update sets auto_datetime, which FOV lacks
+            obj = FOV.objects.get(pk=fov['id'])
+            obj.stack = stack
+            obj.save()
+        self.assertEqual(3, stack.slices.count())
+
+        r = self.client.get(reverse('imagingstack-list') + '?limit=250')
+        self.assertEqual(200, r.status_code)
+        self.assertEqual(1, r.data['count'])
+        self.assertEqual(1, len(r.data['results']), 'the stack must not repeat per slice')
+        # and its slices are ordered by name rather than however they were created
+        slices = r.data['results'][0]['slices']
+        self.assertEqual(['FOV_00', 'FOV_01', 'FOV_02'], [s['name'] for s in slices])
+
+    def test_session_list_ordering_uses_number(self):
+        """Sessions sharing a start time are ordered by number, not by whatever the database picks.
+
+        Session declares no uniqueness, and 916 of them share a start time with another, so the
+        sort key needs more than the start time to place them.
+        """
+        start = now()
+        subject = self.session.subject
+        created = [Session.objects.create(subject=subject, start_time=start, number=n)
+                   for n in (3, 1, 2)]
+        r = self.client.get(reverse('session-list') + f'?subject={subject.nickname}&limit=250')
+        rows = [x for x in self.ar(r) if x['id'] in {str(s.pk) for s in created}]
+        self.assertEqual([1, 2, 3], [x['number'] for x in rows])
+
+    def test_fov_dataset_qc_filter(self):
+        """FOVs are matched on the QC of their datasets, as sessions and insertions are."""
+        # the datasets must exist before the fields of view: the FOV post_save signal is what
+        # associates them, by matching the FOV name against the dataset collection
+        dtype, _ = DatasetType.objects.get_or_create(name='obj.attr')
+        for fov_name, name, qc in (('FOV_00', 'obj.attr.npy', 10),    # PASS
+                                   ('FOV_00', 'obj.times.npy', 10),   # a second qualifying dset
+                                   ('FOV_01', 'obj.attr.npy', 40),    # FAIL
+                                   ('FOV_02', 'obj.attr.npy', 50)):   # CRITICAL
+            Dataset.objects.create(session=self.session, name=name, dataset_type=dtype,
+                                   collection=f'alf/{fov_name}', qc=qc)
+        url = reverse('fieldsofview-list')
+        fovs = {}
+        for name in ('FOV_00', 'FOV_01', 'FOV_02'):
+            fovs[name] = self.ar(self.post(url, dict(self.dict_fov, name=name)), 201)['id']
+
+        # FOV_00 has two datasets at PASS and must still be returned exactly once
+        r = self.client.get(url + '?dataset_qc_lte=PASS')
+        self.assertEqual(1, r.data['count'])
+        self.assertEqual([fovs['FOV_00']], [x['id'] for x in r.data['results']])
+
+        r = self.client.get(url + '?dataset_qc_lte=FAIL')
+        self.assertEqual(sorted([fovs['FOV_00'], fovs['FOV_01']]),
+                         sorted(x['id'] for x in self.ar(r)))
+
+        # a QC code should work as well as a name, as on the other endpoints
+        d = self.ar(self.client.get(url + '?dataset_qc_lte=10'))
+        self.assertEqual([fovs['FOV_00']], [x['id'] for x in d])
+
+        # combined with datasets, the datasets filter applies the QC bound to the named dataset
+        d = self.ar(self.client.get(url + '?datasets=obj.attr.npy&dataset_qc_lte=PASS'))
+        self.assertEqual([fovs['FOV_00']], [x['id'] for x in d])
+        d = self.ar(self.client.get(url + '?datasets=obj.attr.npy&dataset_qc_lte=FAIL'))
+        self.assertEqual(sorted([fovs['FOV_00'], fovs['FOV_01']]),
+                         sorted(x['id'] for x in d))
+        # obj.times.npy is only on FOV_00, and only at PASS
+        d = self.ar(self.client.get(url + '?datasets=obj.attr.npy,obj.times.npy'))
+        self.assertEqual([fovs['FOV_00']], [x['id'] for x in d])
 
     def test_fov_tag_filter(self):
         """FOVs are matched via the tags of their datasets, without duplicating rows."""

--- a/alyx/experiments/tests_rest.py
+++ b/alyx/experiments/tests_rest.py
@@ -8,7 +8,7 @@ from alyx.base import BaseTests
 from actions.models import Session, ProcedureType
 from misc.models import Lab
 from subjects.models import Subject, Project
-from experiments.models import ProbeInsertion, ImagingType
+from experiments.models import ProbeInsertion, ImagingType, FOV
 from data.models import Dataset, DatasetType, Tag
 
 
@@ -193,6 +193,48 @@ class APIProbeExperimentTests(BaseTests):
         urlf = (reverse('dataset-list') + '?&probe_insertion=' + insertions[0]['id'])
         datasets = self.ar(self.client.get(urlf))
         self.assertTrue(len(datasets) == 2)
+
+    def test_probe_insertion_tag_filter(self):
+        """Insertions are matched via the tags of their datasets, without duplicating rows."""
+        tag = Tag.objects.create(name='2020_Q1_Test_et_al')
+        other_tag = Tag.objects.create(name='unrelated_tag')
+        url = reverse('probeinsertion-list')
+        ins = [ProbeInsertion.objects.create(session=self.session, name=f'probe0{i}')
+               for i in range(3)]
+        # two tagged datasets on the same insertion must not duplicate it in the response
+        for name in ('obj.attr.npy', 'obj.times.npy'):
+            dset = Dataset.objects.create(session=self.session, name=name)
+            dset.tags.add(tag)
+            ins[0].datasets.add(dset)
+        dset = Dataset.objects.create(session=self.session, name='obj.attr.npy')
+        dset.tags.add(tag, other_tag)
+        ins[1].datasets.add(dset)
+        dset = Dataset.objects.create(session=self.session, name='obj.attr.npy')
+        dset.tags.add(other_tag)
+        ins[2].datasets.add(dset)
+        # a tagged dataset belonging to no insertion must not affect the filter
+        Dataset.objects.create(name='aggregate.attr.npy').tags.add(tag)
+
+        expected = sorted([str(ins[0].pk), str(ins[1].pk)])
+        d = self.ar(self.client.get(url + f'?tag={tag.name}'))
+        self.assertEqual(expected, sorted(x['id'] for x in d))
+
+        # the lookup is a case-insensitive partial match on the tag name
+        d = self.ar(self.client.get(url + '?tag=test_ET_al'))
+        self.assertEqual(expected, sorted(x['id'] for x in d))
+
+        d = self.ar(self.client.get(url + f'?tag={other_tag.name}'))
+        self.assertEqual(sorted([str(ins[1].pk), str(ins[2].pk)]),
+                         sorted(x['id'] for x in d))
+
+        d = self.ar(self.client.get(url + '?tag=no_such_tag'))
+        self.assertEqual([], d)
+
+        # combining with another many-to-many filter must not duplicate rows either: the
+        # project lookup matches both of the session's projects
+        self.session.projects.add(Project.objects.get_or_create(name='brain_wide_map')[0])
+        d = self.ar(self.client.get(url + f'?tag={tag.name}&project=brain_wide'))
+        self.assertEqual(expected, sorted(x['id'] for x in d))
 
     def test_create_list_delete_trajectory(self):
         # first create a probe insertion
@@ -500,3 +542,45 @@ class APIImagingExperimentTests(BaseTests):
         # First location in list should be default provenance = True
         self.assertEqual([True, False], [x['default_provenance'] for x in r[0]['location']])
         self.assertIn(355, r[0]['location'][0]['brain_region'])
+
+    def test_fov_tag_filter(self):
+        """FOVs are matched via the tags of their datasets, without duplicating rows."""
+        tag = Tag.objects.create(name='2020_Q1_Test_et_al')
+        other_tag = Tag.objects.create(name='unrelated_tag')
+        # the datasets must exist before the fields of view: the FOV post_save signal is what
+        # associates them, by matching the FOV name against the dataset collection
+        dsets = {
+            ('FOV_00', 'obj.attr.npy'): [tag],
+            ('FOV_00', 'obj.times.npy'): [tag],  # two tagged datasets on one FOV
+            ('FOV_01', 'obj.attr.npy'): [tag, other_tag],
+            ('FOV_02', 'obj.attr.npy'): [other_tag],
+        }
+        for (fov_name, dset_name), tags in dsets.items():
+            dset = Dataset.objects.create(
+                session=self.session, name=dset_name, collection=f'alf/{fov_name}')
+            dset.tags.add(*tags)
+        # a tagged dataset belonging to no field of view must not affect the filter
+        Dataset.objects.create(name='aggregate.attr.npy').tags.add(tag)
+
+        url = reverse('fieldsofview-list')
+        fovs = {}
+        for name in ('FOV_00', 'FOV_01', 'FOV_02'):
+            d = self.ar(self.post(url, dict(self.dict_fov, name=name)), 201)
+            fovs[name] = d['id']
+        # the signal should have associated the datasets with their field of view
+        self.assertEqual(2, len(FOV.objects.get(pk=fovs['FOV_00']).datasets.all()))
+
+        expected = sorted([fovs['FOV_00'], fovs['FOV_01']])
+        r = self.ar(self.client.get(url + f'?tag={tag.name}'), 200)
+        self.assertEqual(expected, sorted(x['id'] for x in r))
+
+        # the lookup is a case-insensitive partial match on the tag name
+        r = self.ar(self.client.get(url + '?tag=test_ET_al'), 200)
+        self.assertEqual(expected, sorted(x['id'] for x in r))
+
+        r = self.ar(self.client.get(url + f'?tag={other_tag.name}'), 200)
+        self.assertEqual(sorted([fovs['FOV_01'], fovs['FOV_02']]),
+                         sorted(x['id'] for x in r))
+
+        r = self.ar(self.client.get(url + '?tag=no_such_tag'), 200)
+        self.assertEqual([], r)

--- a/alyx/experiments/views.py
+++ b/alyx/experiments/views.py
@@ -7,6 +7,7 @@ from django.db.models import Count, Q
 
 
 from alyx.base import BaseFilterSet, rest_permission_classes
+from data.models import Dataset
 from experiments.models import (ProbeInsertion, TrajectoryEstimate, Channel, BrainRegion,
                                 ChronicInsertion, FOV, FOVLocation, ImagingStack)
 from experiments.serializers import (ProbeInsertionListSerializer, ProbeInsertionDetailSerializer,
@@ -88,13 +89,20 @@ class ProbeInsertionFilter(BaseFilterSet):
         """
         returns insertions that contain datasets tagged as
         :param queryset:
-        :param name:
         :param value:
         :return:
+
+        The matching insertions are resolved in a separate query rather than joining the datasets
+        into the insertion query. A tag covers tens of thousands of datasets but only a few
+        hundred insertions, and joining them in fans the insertion rows out by that ratio, then
+        forces the DISTINCT to deduplicate over the full insertion, model, session, subject and
+        lab row. Passing the insertion IDs in as a literal list also keeps the query planner from
+        re-planning this as a correlated sub-plan over the whole insertion table.
         """
-        queryset = queryset.filter(
-            datasets__tags__name__icontains=value).distinct()
-        return queryset
+        insertion_ids = (Dataset.objects
+                         .filter(tags__name__icontains=value, probe_insertion__isnull=False)
+                         .values_list('probe_insertion', flat=True).distinct())
+        return queryset.filter(pk__in=list(insertion_ids)).distinct()
 
     def atlas(self, queryset, name, value):
         """
@@ -381,6 +389,7 @@ class FOVFilter(BaseFilterSet):
     dataset_types = CharFilter(field_name='dataset_types', method='filter_dataset_types')
     datasets = CharFilter(field_name='datasets', method='filter_datasets')
     imaging_type = CharFilter(field_name='imaging_type__name', lookup_expr='icontains')
+    tag = CharFilter(field_name='tag', method='filter_tag')
     # brain region filters
     atlas_name = CharFilter(field_name='name__icontains', method='atlas')
     atlas_acronym = CharFilter(field_name='acronym__iexact', method='atlas')
@@ -395,10 +404,16 @@ class FOVFilter(BaseFilterSet):
     def filter_tag(self, queryset, _, value):
         """
         Returns FOVs that contain datasets with the provided tag
+
+        As for the sessions and probe insertions tag filters, the matching FOVs are resolved in a
+        separate query: joining the datasets in fans the FOV rows out by the number of tagged
+        datasets each one has, and the DISTINCT that removes them then has to deduplicate over the
+        full FOV row. No FOV datasets are tagged yet, so this is currently cheap either way.
         """
-        queryset = queryset.filter(
-            datasets__tags__name__icontains=value).distinct()
-        return queryset
+        fov_ids = (Dataset.objects
+                   .filter(tags__name__icontains=value, field_of_view__isnull=False)
+                   .values_list('field_of_view', flat=True).distinct())
+        return queryset.filter(pk__in=list(fov_ids)).distinct()
 
     def filter_dataset_types(self, queryset, _, value):
         """
@@ -442,6 +457,11 @@ class FOVList(generics.ListCreateAPIView):
     -   **experiment_number**: session number `/fields-of-view?experiment_number=1`
     -   **session**: `/fields-of-view?session=aad23144-0e52-4eac-80c5-c4ee2decb198`
     -   **name**: field of view name `/trajectories?name=FOV_01`
+    -   **tag**: tag name of the associated datasets (icontains)
+        `/fields-of-view?tag=2021_Q1_IBL_et_al_Behaviour`
+    -   **dataset_types**: dataset type(s)
+    -   **datasets**: dataset name(s)
+    -   **imaging_type**: imaging type name (icontains)
 
     [===> FOV model reference](/admin/doc/models/experiments.fov)
     """

--- a/alyx/experiments/views.py
+++ b/alyx/experiments/views.py
@@ -3,7 +3,7 @@ import logging
 from one.alf.spec import QC
 from rest_framework import generics
 from django_filters.rest_framework import CharFilter, UUIDFilter, NumberFilter
-from django.db.models import Count, Q
+from django.db.models import Count, Exists, OuterRef
 
 
 from alyx.base import BaseFilterSet, rest_permission_classes
@@ -32,38 +32,50 @@ def _filter_qs_with_brain_regions(queryset, region_field: str, region_value: str
     :param region_field: The BrainRegion model field to filter, e.g. id, name, acronym.
     :param region_value: The brain region to filter.
     :return: The filtered queryset.
+
+    The IDs of the matching rows are resolved from the trajectories and field of view locations
+    first, rather than joining those into the outer query: a row was previously returned once per
+    matching channel, and the Session and ImagingStack branches had no DISTINCT to remove the
+    duplicates again, so both the paginated rows and the reported count came back inflated.
     """
     brs = (BrainRegion.objects
            .filter(**{region_field: region_value})
            .get_descendants(include_self=True))
     qs_trajs = (TrajectoryEstimate.objects
                 .filter(provenance__gte=70)
-                .prefetch_related('channels__brain_region')
-                .filter(channels__brain_region__in=brs)
-                .distinct())
+                .filter(channels__brain_region__in=brs))
     qs_fov_loc = (FOVLocation.objects
                   .filter(default_provenance=True)
-                  .prefetch_related('brain_region')
-                  .filter(brain_region__in=brs)
-                  .distinct())
-    if queryset.model.__name__ == 'Session':
-        probe_in_region = Q(probe_insertion__trajectory_estimate__in=qs_trajs)
-        fov_in_region = Q(field_of_view__location__in=qs_fov_loc)
-        qs = (queryset
-              .prefetch_related('probe_insertion__trajectory_estimate', 'field_of_view__location')
-              .filter(probe_in_region | fov_in_region))
-    elif (queryset.model.__name__ == 'ProbeInsertion' or
-          queryset.model.__name__ == 'ChronicInsertion'):
-        qs = queryset.prefetch_related('trajectory_estimate').filter(
-            trajectory_estimate__in=qs_trajs)
-    elif queryset.model.__name__ == 'FOV':
-        qs = queryset.prefetch_related('location').filter(location__in=qs_fov_loc)
-    elif queryset.model.__name__ == 'ImagingStack':
-        qs = queryset.prefetch_related('slices').filter(slices__location__in=qs_fov_loc)
+                  .filter(brain_region__in=brs))
+
+    def ids_of(queryset_, field):
+        """The distinct non-null values of `field`, e.g. the insertions of the trajectories.
+
+        Restricting the subquery to rows that have the field set matters: it lets the planner
+        start from those rows instead of resolving every trajectory in the region first, which
+        is what makes this cheap for the models few trajectories point at.
+        """
+        values = (queryset_
+                  .filter(**{f'{field}__isnull': False})
+                  .values_list(field, flat=True))
+        return set(values)
+
+    model = queryset.model.__name__
+    if model == 'Session':
+        ids = (ids_of(qs_trajs, 'probe_insertion__session') |
+               ids_of(qs_fov_loc, 'field_of_view__session'))
+    elif model in ('ProbeInsertion', 'ChronicInsertion'):
+        # both models are the target of a TrajectoryEstimate foreign key named after them
+        insertion = 'probe_insertion' if model == 'ProbeInsertion' else 'chronic_insertion'
+        ids = ids_of(qs_trajs, insertion)
+    elif model == 'FOV':
+        ids = ids_of(qs_fov_loc, 'field_of_view')
+    elif model == 'ImagingStack':
+        ids = ids_of(qs_fov_loc, 'field_of_view__stack')
     else:
-        logger.error('Filtering by brain region with a %s query set not supported',
-                     queryset.model.__name__)
-    return qs
+        logger.error('Filtering by brain region with a %s query set not supported', model)
+        raise NotImplementedError(f'brain region filter not supported for {model}')
+    return queryset.filter(pk__in=list(ids))
 
 
 class ProbeInsertionFilter(BaseFilterSet):
@@ -111,29 +123,62 @@ class ProbeInsertionFilter(BaseFilterSet):
         return _filter_qs_with_brain_regions(queryset, name, value)
 
     def filter_dataset_types(self, queryset, _, value):
+        """
+        Returns insertions associated with datasets of all of the given type(s)
 
+        The datasets are counted per insertion in a subquery instead of being joined into the
+        insertion query and grouped there: the GROUP BY then covers the full insertion, model,
+        session, subject and lab row rather than a single ID column.
+        """
         dtypes = value.split(',')
-        queryset = queryset.filter(datasets__dataset_type__name__in=dtypes)
-        queryset = queryset.annotate(
-            dtypes_count=Count('datasets__dataset_type', distinct=True))
-        queryset = queryset.filter(dtypes_count__gte=len(dtypes))
-        return queryset
+        insertions = (Dataset.objects
+                      .filter(dataset_type__name__in=dtypes, probe_insertion__isnull=False)
+                      .values('probe_insertion')
+                      .annotate(dtypes_count=Count('dataset_type__name', distinct=True))
+                      .filter(dtypes_count__gte=len(dtypes))
+                      .values_list('probe_insertion', flat=True))
+        return queryset.filter(pk__in=insertions)
 
     def filter_datasets(self, queryset, _, value):
+        """
+        Returns insertions associated with all of the given dataset(s)
+
+        As for `filter_dataset_types`, the datasets are counted per insertion in a subquery. The
+        sessions filter of the same name special-cases a single dataset name into an Exists
+        semi-join; that is deliberately not done here, as it measured no faster either way. There
+        are two orders of magnitude fewer insertions than sessions to probe, which leaves the whole
+        query under 100 ms whichever form is used.
+
+        The distinct dataset *names* are counted, not the datasets: one name routinely matches
+        several datasets of an insertion, across collections and revisions, and counting those
+        instead let an insertion holding two copies of one requested name satisfy a request for
+        two different names.
+        """
         qc = QC.validate(self.request.query_params.get('dataset_qc_lte', QC.FAIL))
-        dsets = value.split(',')
-        queryset = queryset.filter(datasets__name__in=dsets, datasets__qc__lte=qc)
-        queryset = queryset.annotate(
-            dsets_count=Count('datasets', distinct=True))
-        queryset = queryset.filter(dsets_count__gte=len(dsets))
-        return queryset
+        dsets = sorted(set(value.split(',')))
+        insertions = (Dataset.objects
+                      .filter(name__in=dsets, qc__lte=qc, probe_insertion__isnull=False)
+                      .values('probe_insertion')
+                      .annotate(dsets_count=Count('name', distinct=True))
+                      .filter(dsets_count__gte=len(dsets))
+                      .values_list('probe_insertion', flat=True))
+        return queryset.filter(pk__in=insertions)
 
     def filter_dataset_qc_lte(self, queryset, _, value):
+        """
+        Returns insertions with at least one dataset whose QC is at most the given value
+
+        An Exists semi-join, so an insertion is returned once no matter how many of its datasets
+        qualify. The previous join returned it once per qualifying dataset, which duplicated the
+        rows across the paginated response and inflated the reported count to the number of
+        (insertion, dataset) pairs.
+        """
         # If filtering on datasets too, `filter_datasets` handles both QC and Datasets
         if 'datasets' in self.request.query_params:
             return queryset
         qc = QC.validate(value)
-        return queryset.filter(datasets__qc__lte=qc)
+        return queryset.filter(
+            Exists(Dataset.objects.filter(probe_insertion=OuterRef('pk'), qc__lte=qc)))
 
     class Meta:
         model = ProbeInsertion
@@ -388,6 +433,7 @@ class FOVFilter(BaseFilterSet):
     experiment_number = CharFilter('session__number')
     dataset_types = CharFilter(field_name='dataset_types', method='filter_dataset_types')
     datasets = CharFilter(field_name='datasets', method='filter_datasets')
+    dataset_qc_lte = CharFilter(field_name='dataset_qc', method='filter_dataset_qc_lte')
     imaging_type = CharFilter(field_name='imaging_type__name', lookup_expr='icontains')
     tag = CharFilter(field_name='tag', method='filter_tag')
     # brain region filters
@@ -418,24 +464,54 @@ class FOVFilter(BaseFilterSet):
     def filter_dataset_types(self, queryset, _, value):
         """
         Returns FOVs associated with the given dataset type(s)
+
+        As for the probe insertions filter of the same name, the datasets are counted per field of
+        view in a subquery rather than joined into this query and grouped there.
         """
         dtypes = value.split(',')
-        queryset = queryset.filter(datasets__dataset_type__name__in=dtypes)
-        queryset = queryset.annotate(
-            dtypes_count=Count('datasets__dataset_type', distinct=True))
-        queryset = queryset.filter(dtypes_count__gte=len(dtypes))
-        return queryset
+        fovs = (Dataset.objects
+                .filter(dataset_type__name__in=dtypes, field_of_view__isnull=False)
+                .values('field_of_view')
+                .annotate(dtypes_count=Count('dataset_type__name', distinct=True))
+                .filter(dtypes_count__gte=len(dtypes))
+                .values_list('field_of_view', flat=True))
+        return queryset.filter(pk__in=fovs)
 
     def filter_datasets(self, queryset, _, value):
         """
         Returns FOVs associated with the given dataset(s)
+
+        Only datasets whose QC is at most `dataset_qc_lte` count, as for the sessions and probe
+        insertions filters of the same name.
+
+        As for the probe insertions filter, the datasets are counted per field of view in a
+        subquery, it is the distinct dataset names that are counted rather than the datasets, and a
+        single name is not special-cased: no dataset is currently associated with any field of
+        view, so there is nothing to measure such a special case against.
         """
-        dsets = value.split(',')
-        queryset = queryset.filter(datasets__name__in=dsets)
-        queryset = queryset.annotate(
-            dsets_count=Count('datasets', distinct=True))
-        queryset = queryset.filter(dsets_count__gte=len(dsets))
-        return queryset
+        qc = QC.validate(self.request.query_params.get('dataset_qc_lte', QC.FAIL))
+        dsets = sorted(set(value.split(',')))
+        fovs = (Dataset.objects
+                .filter(name__in=dsets, qc__lte=qc, field_of_view__isnull=False)
+                .values('field_of_view')
+                .annotate(dsets_count=Count('name', distinct=True))
+                .filter(dsets_count__gte=len(dsets))
+                .values_list('field_of_view', flat=True))
+        return queryset.filter(pk__in=fovs)
+
+    def filter_dataset_qc_lte(self, queryset, _, value):
+        """
+        Returns FOVs with at least one dataset whose QC is at most the given value
+
+        An Exists semi-join, so a field of view is returned once no matter how many of its datasets
+        qualify.
+        """
+        # If filtering on datasets too, `filter_datasets` handles both QC and Datasets
+        if 'datasets' in self.request.query_params:
+            return queryset
+        qc = QC.validate(value)
+        return queryset.filter(
+            Exists(Dataset.objects.filter(field_of_view=OuterRef('pk'), qc__lte=qc)))
 
     class Meta:
         model = FOV
@@ -461,6 +537,8 @@ class FOVList(generics.ListCreateAPIView):
         `/fields-of-view?tag=2021_Q1_IBL_et_al_Behaviour`
     -   **dataset_types**: dataset type(s)
     -   **datasets**: dataset name(s)
+    -   **dataset_qc_lte**: dataset QC value, e.g. PASS, WARNING, FAIL, CRITICAL
+        `/fields-of-view?dataset_qc_lte=WARNING`
     -   **imaging_type**: imaging type name (icontains)
 
     [===> FOV model reference](/admin/doc/models/experiments.fov)

--- a/alyx/misc/admin.py
+++ b/alyx/misc/admin.py
@@ -1,9 +1,12 @@
+from contextlib import suppress
+
 from pytz import all_timezones
 
 from django import forms
 from django.db import models
 from django.db.models import Q
 from django.contrib import admin
+from django.contrib.admin.exceptions import NotRegistered
 from django.contrib.admin.widgets import AdminFileWidget
 from django.contrib.contenttypes.admin import GenericTabularInline
 from django.contrib.postgres.fields import JSONField
@@ -306,4 +309,8 @@ admin.site.register(Note, NoteAdmin)
 admin.site.register(CageType, CageTypeAdmin)
 admin.site.register(Enrichment, EnrichmentAdmin)
 admin.site.register(Food, FoodAdmin)
-admin.site.unregister(TokenProxy)
+# DRF registers a token admin on the default site; Alyx issues tokens through /auth-token and
+# does not want them editable here. Tolerate its absence so that a DRF release which stops
+# registering it cannot break startup for the sake of a cosmetic removal.
+with suppress(NotRegistered):
+    admin.site.unregister(TokenProxy)

--- a/alyx/subjects/admin.py
+++ b/alyx/subjects/admin.py
@@ -7,7 +7,6 @@ from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.forms import UserChangeForm
-from django.contrib.auth.models import Group
 from django.core.exceptions import ValidationError
 from django.db.models import Case, When, Count, Prefetch
 from django.forms import BaseInlineFormSet
@@ -1421,7 +1420,6 @@ class LabMemberAdmin(UserAdmin):
 mysite = admin.site
 
 mysite.register(LabMember, LabMemberAdmin)
-mysite.register(Group)
 
 mysite.register(Project, ProjectAdmin)
 mysite.register(Subject, SubjectAdmin)

--- a/deploy/app/docker/settings-deploy.py
+++ b/deploy/app/docker/settings-deploy.py
@@ -121,7 +121,8 @@ CSRF_COOKIE_SECURE = True
 INSTALLED_APPS = (
     'django_admin_listfilter_dropdown',
     'django_filters',
-    'django.contrib.admin',
+    # Provides django.contrib.admin, with alyx.base.MyAdminSite as the default admin site
+    'alyx.apps.AlyxAdminConfig',
     'django.contrib.admindocs',
     'django.contrib.contenttypes',
     'django.contrib.auth',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3
 colorlog
-django>=5.2.15,<6  # see issue #963
+django>=5.2.16,<6  # see issue #963
 django-admin-list-filter-dropdown
 django-admin-rangefilter
 django-autocomplete-light

--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -70,7 +70,7 @@ ruff==0.11.11
 s3transfer==0.13.0
 setuptools==80.9.0
 six==1.17.0
-sqlparse==0.5.4
+sqlparse==0.6.0
 structlog==25.3.0
 tqdm==4.67.1
 tzdata==2025.2

--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -11,7 +11,7 @@ coreapi==2.3.3
 coreschema==0.0.4
 coverage==7.8.2
 coveralls==4.0.1
-cryptography==48.0.1
+cryptography==50.0.0
 cycler==0.12.1
 Django==5.2.15
 django-admin-list-filter-dropdown==1.0.3

--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -13,7 +13,7 @@ coverage==7.8.2
 coveralls==4.0.1
 cryptography==50.0.0
 cycler==0.12.1
-Django==5.2.15
+Django==5.2.16
 django-admin-list-filter-dropdown==1.0.3
 django-admin-rangefilter==0.13.2
 django-autocomplete-light==3.12.1


### PR DESCRIPTION
## [3.6.4]

### Fixed

- Sessions and probe insertions `tag` REST filters no longer join the datasets table into the
  main query, which made them 3-174x faster.
- `tag` filter on the fields-of-view REST endpoint. `FOVFilter` had a `filter_tag` method but
  never declared the filter that routes to it, so `/fields-of-view?tag=` was silently ignored.
- `dataset_qc_lte` REST filter returned sessions and insertions once per matching dataset, so the
  rows repeated across the paginated response and the count was the number of (row, dataset)
  pairs: `/sessions?dataset_qc_lte=WARNING` reported 3,234,065 of 94,594 sessions.
- `atlas_name`, `atlas_acronym` and `atlas_id` REST filters returned a session once per insertion
  recording the region, and likewise an imaging stack once per slice.
- The `dataset_types`, `datasets`, `dataset_qc_lte` and `atlas_*` REST filters now count and match
  in a subquery instead of joining and grouping over the full row, making them up to 3.5x faster
  (`/sessions?datasets=` 55 s to 16 s, `/chronic-insertions?atlas_acronym=` 0.7 s to 0.01 s).
  `/insertions?tag=&dataset_qc_lte=` previously timed out, as the two joins multiplied.
- The `datasets` REST filter counted the matching datasets rather than the distinct names on the
  insertions and fields-of-view endpoints, so a row holding two datasets of one requested name
  passed as having two different ones: `/insertions?datasets=` now agrees with `/sessions?datasets=`.
  One name matches several datasets across collections and revisions for 142,624 (session, name)
  and 50,078 (insertion, name) pairs, so this over-returned by ~4x on affected queries.
- A dataset name repeated in a `datasets` REST filter, e.g. `?datasets=obj.attr.npy,obj.attr.npy`,
  returned nothing at all rather than the rows having that dataset.
- The chronic insertions REST list eagerly loaded its nested probe insertions while serialising
  each row, which discarded the prefetched result and cost two queries per chronic insertion:
  `/chronic-insertions` issued 329 queries for 176 rows, and now issues 4 regardless of the number
  of rows (1.7x faster overall, 2.3x less time in the database).
- The projects of a session, and the probe insertions of a chronic insertion, are now serialised in
  a defined order. `Project` has no `Meta.ordering` and insertions of one chronic insertion often
  share a session start time and name, so the database was free to return either in any order.
- The sessions, insertions, fields-of-view and chronic insertions REST lists are now totally
  ordered, so a page is the same from one request to the next. 916 sessions share a start time with
  another and 120 insertions share a session start time and name, and rows tied that way came back
  in a different order each request; `/chronic-insertions` had no ordering at all. The keys are
  now `(-start_time, number, subject, pk)` for sessions and `(-session start_time, name, subject,
  session number, pk)` for insertions and fields of view, the primary key being what makes them
  total: `Session` and `ChronicInsertion` declare no uniqueness, and the insertion constraint is on
  (session, name), which does not separate two sessions sharing a start time.
- `/imaging-stacks` returned a stack once per slice, serving 250 rows covering 162 of the 174
  stacks while reporting 174, as the list was ordered by `slices__name` and so joined the slices
  into the query. The stacks are ordered by their own fields now and the slices within each stack
  by the prefetch.
- Admin no longer fails to start with djangorestframework >= 3.18

### Added

- `dataset_qc_lte` filter on the fields-of-view REST endpoint, matching the sessions and probe
  insertions endpoints. The `datasets` filter there now applies the QC bound too, as it does on
  those endpoints, rather than ignoring it.
- Index on `data_dataset.name`, which the `?datasets=` REST filters look up and which had no index
  (23 MB; deduplicated, as a few hundred names repeat across the table). Built concurrently, as
  the table is continuously written. `/insertions?datasets=` is 7x faster, but note
  `/sessions?datasets=` with two or more names is ~1.3x slower, as the planner switches from a
  parallel sequential scan to a bitmap scan past roughly 5% of the table.
- A single dataset name in the sessions `datasets` REST filter is now matched with one Exists
  semi-join anchored on the session, rather than gathering every dataset of that name in the table
  to group them: `/sessions?datasets=` with one name is 1.8x faster (9.9 s to 5.4 s), and 8x faster
  than before this release. Several names, or a `dataset_qc_lte` below WARNING, keep the grouped
  count, both being cases where the semi-join measured no better or worse. The insertions and
  fields-of-view filters are not special-cased, measuring the same either way.

### Changed
- The custom admin site is now installed through `alyx.apps.AlyxAdminConfig` instead of by
  reassigning `django.contrib.admin.site`. **Deployments must replace `'django.contrib.admin'`
  with `'alyx.apps.AlyxAdminConfig'` in their `INSTALLED_APPS`**, otherwise the stock Django
  admin index is served in place of the Alyx one. `alyx.base.mysite` is gone; use
  `django.contrib.admin.site`, which now refers to the site Alyx serves.
- Groups are administered through `django.contrib.auth`'s `GroupAdmin` rather than a bare
  `ModelAdmin`, so group permissions get the two-pane selector
