### PR TITLE
pandas 3 fix for revisions in one_cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.7.0]
 
+### Fixed
+
+- Relative paths correctly rendered in cache table using pandas 3.
+
 ## [3.6.4]
 
 ### Fixed

--- a/alyx/misc/management/commands/one_cache.py
+++ b/alyx/misc/management/commands/one_cache.py
@@ -359,7 +359,7 @@ def dataset_queryset_to_dataframe(ds: QuerySet, batch_size: int = 100_000) -> pd
         df['exists'] = True
 
         # relative_path
-        revision = map(lambda x: None if not x else f'#{x}#', df.pop('revision__name'))
+        revision = map(lambda x: None if not x or pd.isna(x) else f'#{x}#', df.pop('revision__name'))
         zipped = zip(df.pop('collection'), revision, df.pop('name'))
         df['rel_path'] = ['/'.join(filter(None, x)) for x in zipped]
 

--- a/alyx/misc/tests.py
+++ b/alyx/misc/tests.py
@@ -11,7 +11,8 @@ import pandas as pd
 from subjects.models import Subject
 from misc.models import Housing, HousingSubject, CageType, LabMember, Lab
 from actions.models import Session
-from data.models import Dataset, DatasetType, DataRepository, FileRecord, DataFormat
+from data.models import (
+    Dataset, DatasetType, DataRepository, FileRecord, DataFormat, Revision)
 
 SKIP_ONE_CACHE = False
 try:
@@ -209,6 +210,27 @@ class ONECache(TestCase):
         self.assertTrue(cache_info.exists())
         zip = zipfile.ZipFile(zip_file)
         self.assertCountEqual(['sessions.pqt', 'cache_info.json', 'QC.json'], zip.namelist())
+
+    def test_dataset_queryset_to_dataframe(self):
+        """Test the dataset_queryset_to_dataframe function.
+
+        Ensures the relative path is correctly rendered for datasets both with and without a
+        revision. In pandas 3 the revision column is of str dtype, meaning the missing values are
+        NaN (a truthy float) instead of None.
+        """
+        # Add a revised copy of one of the datasets
+        dataset = Dataset.objects.first()
+        revision = Revision.objects.create(name='2024-05-06')
+        Dataset.objects.create(
+            session=dataset.session, dataset_type=dataset.dataset_type, collection='alf',
+            name=dataset.name, data_format=dataset.data_format, revision=revision, qc=QC.PASS)
+
+        df = one_cache.dataset_queryset_to_dataframe(Dataset.objects.all())
+        self.assertEqual(Dataset.objects.count(), len(df))
+        # The revised dataset should include the revision folder, the others should have none
+        expected = {
+            'alf/foo.bar.npy', 'alf/bar.baz.bin', f'alf/#2024-05-06#/{dataset.name}'}
+        self.assertEqual(expected, set(df['rel_path']))
 
     def test_s3_filesystem(self):
         """Test the _s3_filesystem function"""


### PR DESCRIPTION
https://github.com/cortex-lab/alyx/blob/4d8c5e2bddbc789db76b0cfcabb10d5b3f494aa9/alyx/misc/management/commands/one_cache.py#L361-L364
Under pandas 2, revision__name was object dtype and a null revision came through as None → falsy → dropped. Under pandas 3 the column is inferred as the new str dtype, whose missing sentinel is nan (a float), which is truthy:
```
pandas 3.0.3
dtype: str
nan          truthy: True  -> #nan#
'2024-05-06' truthy: True  -> #2024-05-06#
```
So the if not x guard never fires and f'#{x}#' formats the NaN. filter(None, ...) doesn't catch it either, for the same reason.